### PR TITLE
Fix the translation of the "Blog archive"

### DIFF
--- a/tinkerer/ext/aggregator.py
+++ b/tinkerer/ext/aggregator.py
@@ -61,5 +61,7 @@ def make_aggregated_pages(app):
             context["next"]["title"] = UIStr.OLDER
             context["next"]["link"] = "page%d.html" % (i + 2)
 
+        context["archive_title"] = UIStr.BLOG_ARCHIVE
+
         yield (pagename, context, "aggregated.html")
 


### PR DESCRIPTION
This patch fix the translation of the "Blog archive" in
`aggregated.html` based in the comment of vladris.

Close issue #10.
