### PR TITLE
Do not depend on argparse unless needed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@
     CONTRIBUTORS file)
     :license: FreeBSD, see LICENSE file
 '''
+import sys
 from setuptools import setup, find_packages
 import tinkerer
 
@@ -23,8 +24,11 @@ RSS feed generation, comments powered by Disqus and more.
 Tinkerer is also highly customizable through Sphinx extensions.
 '''
 
+requires = ["Jinja2>=2.3", "Sphinx>=1.1"]
+if sys.version_info[:2] < (2,7) or (sys.version_info.major == 3 and
+                                    sys.version_info.minor < 2):
+    requires.append("argparse>=1.2")
 
-requires = ["Jinja2>=2.3", "Sphinx>=1.1", "argparse>=1.2"]
 test_requires = ['nose', 'tox']
 
 setup(


### PR DESCRIPTION
Python 2.7 and Python 3.2 distribute argparse as part of the standard library.
 Installing an external argparse module should be avoided on these versions.
