### PR TITLE
Date formatting depends on current locale

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ RSS feed generation, comments powered by Disqus and more.
 Tinkerer is also highly customizable through Sphinx extensions.
 '''
 
-requires = ["Jinja2>=2.3", "Sphinx>=1.1"]
+requires = ["Jinja2>=2.3", "Sphinx>=1.1", "Babel>=1.3"]
 if sys.version_info[:2] < (2,7) or (sys.version_info.major == 3 and
                                     sys.version_info.minor < 2):
     requires.append("argparse>=1.2")

--- a/tinkerer/ext/metadata.py
+++ b/tinkerer/ext/metadata.py
@@ -12,7 +12,10 @@
 import re
 import datetime
 import locale
+from functools import partial
 from sphinx.util.compat import Directive
+from babel.core import Locale
+from babel.dates import format_date
 import tinkerer
 from tinkerer.ext.uistr import UIStr
 from tinkerer.utils import name_from_title
@@ -24,10 +27,6 @@ def initialize(app):
     Initializes metadata in environment.
     '''
     app.builder.env.blog_metadata = dict()
-
-    # make sure we use system locale for date formatting
-    locale.setlocale(locale.LC_TIME, '')
-
 
 
 class Metadata:
@@ -82,6 +81,12 @@ def get_metadata(app, docname):
     Extracts metadata from a document.
     '''
     env = app.builder.env
+    language = app.config.language
+    locale = Locale.parse(language) if language else Locale.default()
+    format_ui_date = partial(
+        format_date, format=UIStr.TIMESTAMP_FMT, locale=locale)
+    format_short_ui_short = partial(
+        format_date, format=UIStr.TIMESTAMP_FMT_SHORT, locale=locale)
 
     env.blog_metadata[docname] = Metadata()
     metadata = env.blog_metadata[docname]
@@ -104,14 +109,8 @@ def get_metadata(app, docname):
 
     # we format date here instead of inside template due to localization issues
     # and Python2 vs Python3 incompatibility
-    metadata.formatted_date = metadata.date.strftime(UIStr.TIMESTAMP_FMT)
-    metadata.formatted_date_short = metadata.date.strftime(UIStr.TIMESTAMP_FMT_SHORT)
-
-    if (hasattr(metadata.formatted_date, "decode")):
-        metadata.formatted_date = metadata.formatted_date.decode("utf-8")
-    if (hasattr(metadata.formatted_date_short, "decode")):
-        metadata.formatted_date_short = metadata.formatted_date_short.decode("utf-8")
-
+    metadata.formatted_date = format_ui_date(metadata.date)
+    metadata.formatted_date_short = format_short_ui_short(metadata.date)
 
 
 def process_metadata(app, env):

--- a/tinkerer/ext/uistr.py
+++ b/tinkerer/ext/uistr.py
@@ -15,10 +15,10 @@ try:
 except:
     # Python 2
     import __builtin__
-    
 
 
-# check whether unicode builtin exists, otherwise strings are unicode by 
+
+# check whether unicode builtin exists, otherwise strings are unicode by
 # default so it can be stubbed
 if "unicode" not in __builtin__.__dict__:
     def unicode(ret, ignore):
@@ -39,8 +39,8 @@ class UIStr:
         UIStr.TAGS = unicode(_("Tags"), "utf-8")
         UIStr.TAGS_CLOUD = unicode(_("Tags Cloud"), "utf-8")
         UIStr.CATEGORIES = unicode(_("Categories"), "utf-8")
-        UIStr.TIMESTAMP_FMT = unicode(_('%B %d, %Y'), "utf-8")
-        UIStr.TIMESTAMP_FMT_SHORT = unicode(_('%b %d'), "utf-8")
+        UIStr.TIMESTAMP_FMT = unicode(_('MMMM dd, yyyy'), "utf-8")
+        UIStr.TIMESTAMP_FMT_SHORT = unicode(_('MMM dd'), "utf-8")
         UIStr.TAGGED_WITH_FMT = unicode(_('Posts tagged with <span class="title_tag">%s</span>'), "utf-8")
         UIStr.FILED_UNDER_FMT = unicode(_('Filed under <span class="title_category">%s</span>'), "utf-8")
         UIStr.NEWER = unicode(_("Newer"), "utf-8")
@@ -48,4 +48,3 @@ class UIStr:
         UIStr.PAGE_FMT = unicode(_("Page %d"), "utf-8")
         UIStr.READ_MORE = unicode(_("Read more..."), "utf-8")
         UIStr.MAIL_HIDDEN_BY_JAVASCRIPT = unicode(_("Javascript must be enabled to see this e-mail address"), "utf-8")
-


### PR DESCRIPTION
In `metadata.py` dates are formatted with `.strftime()` on date objects.  This method is locale-aware and formats dates according to the current environment locale, that is, the value of `$LANG` or `$LC_*`.

Hence, formatting of dates in posts depends on the environment in which Tinkerer is run, and **ignores** the `language` setting in `conf.py`.  

To build an English language blog on a system with, say, a German locale, you currently need to set `LANG` to `en_US.utf8` explicitly (or a similar English-language locale) to make the post dates appear in English.  Otherwise they will be German, i.e. `Januar 1, 2013` instead of `January 1, 2013`.

I can submit a pull request to fix this issue, but it would introduce a dependency against the Babel i18n library.  Is that acceptable?
