### PR TITLE
if app.config.language is None then fall back to English

### DIFF
--- a/tinkerer/ext/metadata.py
+++ b/tinkerer/ext/metadata.py
@@ -82,7 +82,7 @@ def get_metadata(app, docname):
     '''
     env = app.builder.env
     language = app.config.language
-    locale = Locale.parse(language) if language else Locale.default()
+    locale = Locale.parse(language) if language else Locale('en', 'US')
     format_ui_date = partial(
         format_date, format=UIStr.TIMESTAMP_FMT, locale=locale)
     format_short_ui_short = partial(


### PR DESCRIPTION
This is fix of https://github.com/vladris/tinkerer/issues/32

I have other idea that app.config.language have 'en'. I do not know which is better.
