### PR TITLE
fixed `ZeroDivisionError: division by zero` in tags_cloud.html

### DIFF
--- a/tinkerer/themes/boilerplate/tags_cloud.html
+++ b/tinkerer/themes/boilerplate/tags_cloud.html
@@ -19,7 +19,7 @@
     {%- set count_min = 1 %}
     {%- set count_max = tags.values()|sort|last %}
     {%- for tag, x in tags|dictsort %}
-      {%- set size = (fontsize_max-fontsize_min)*(x-count_min)/(count_max-count_min) + fontsize_min %}
+      {%- set size = (fontsize_max-fontsize_min)*(x-count_min)/(count_max-count_min or 1) + fontsize_min %}
       <a href="{{ pathto('tags/' + taglinks[tag]) }}" style="font-size: {{ size|int }}pt">{{ tag }}</a>
       {%- if not loop.last %}&nbsp;&nbsp;{%- endif %}
     {%- endfor %}


### PR DESCRIPTION
I used `tinker --build` command with enabled tags cloud, but was throwing errors below.

```
$ tinker -b
...
...
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [ 16%] 2013/11/19/something
Exception occurred:
  File "/python2.7/site-packages/tinkerer/themes/boilerplate/tags_cloud.html", line 22, in top-level template code
    {%- set size = (fontsize_max-fontsize_min)*(x-count_min)/(count_max-count_min) + fontsize_min %}
ZeroDivisionError: division by zero
The full traceback has been saved in /var/folders/yc/2zd6v8td575bnv20qb608nd40000gn/T/sphinx-err-O5eNRN.log, if you want to report the issue to the developers.
```
