### PR TITLE
Fix flake8 errors and enable in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,11 @@ python:
 # command to install dependencies
 install: 
   - python setup.py develop
-  - pip install coveralls
+  - pip install coveralls flake8
 
 # command to run tests
-script: 
+script:
+  - flake8 tinkerer tinkertest
   - nosetests --with-coverage --cover-package=tinkerer
 
 # after test run

--- a/tinkerer/__templates/conf.py
+++ b/tinkerer/__templates/conf.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+# flake8: noqa
+
 import tinkerer
 import tinkerer.paths
 
@@ -39,7 +41,7 @@ html_favicon = 'tinkerer.ico'
 html_theme = "{{ theme }}"
 
 # Theme-specific options, see docs
-html_theme_options = { }
+html_theme_options = {}
 
 # Link to RSS service like FeedBurner if any, otherwise feed is
 # linked directly

--- a/tinkerer/cmdline.py
+++ b/tinkerer/cmdline.py
@@ -22,7 +22,6 @@ import tinkerer
 from tinkerer import draft, output, page, paths, post, writer
 
 
-
 def setup():
     '''
     Sets up a new blog in the current directory.
@@ -33,10 +32,10 @@ def setup():
     output.filename.info("conf.py")
     if new_blog:
         output.write.info("Your new blog is almost ready!")
-        output.write.info("You just need to edit a couple of lines in %s" % (os.path.relpath(paths.conf_file), ))
+        output.write.info("You just need to edit a couple of lines in %s" %
+                          (os.path.relpath(paths.conf_file), ))
     else:
         output.write.info("Done")
-
 
 
 def build():
@@ -63,7 +62,6 @@ def build():
     return sphinx.main(flags)
 
 
-
 def create_post(title, date, template):
     '''
     Creates a new post with the given title or makes an existing file a post.
@@ -80,7 +78,6 @@ def create_post(title, date, template):
         output.write.info("Draft moved to post '%s'" % new_post.path)
     else:
         output.write.info("New post created as '%s'" % new_post.path)
-
 
 
 def create_page(title, template):
@@ -101,7 +98,6 @@ def create_page(title, template):
         output.write.info("New page created as '%s'" % new_page.path)
 
 
-
 def create_draft(title, template):
     '''
     Creates a new draft with the given title or makes an existing file a draft.
@@ -118,7 +114,6 @@ def create_draft(title, template):
         output.write.info("File moved to draft '%s'" % new_draft)
     else:
         output.write.info("New draft created as '%s'" % new_draft)
-
 
 
 def preview_draft(draft_file):
@@ -141,51 +136,60 @@ def preview_draft(draft_file):
     return result
 
 
-
 def main(argv=None):
     '''
     Parses command line and executes required action.
     '''
     parser = argparse.ArgumentParser()
     group = parser.add_mutually_exclusive_group()
-    group.add_argument("-s", "--setup", action="store_true", help="setup a new blog")
+    group.add_argument("-s", "--setup", action="store_true",
+                       help="setup a new blog")
     group.add_argument("-b", "--build", action="store_true", help="build blog")
-    group.add_argument("-p", "--post", nargs=1,
-            help="create a new post with the title POST (if a file named POST "
-                 "exists, it is moved to a new post instead)")
-    group.add_argument("--page", nargs=1,
-            help="create a new page with the title PAGE (if a file named PAGE "
-                 "exists, it is moved to a new page instead)")
-    group.add_argument("-d", "--draft", nargs=1,
-            help="creates a new draft with the title DRAFT (if a file named DRAFT "
-                 "exists, it is moved to a new draft instead)")
-    group.add_argument("--preview", nargs=1,
-            help="rebuilds the blog, including the draft PREVIEW, without permanently "
-                 "promoting the draft to a post")
-    group.add_argument("-v", "--version", action="store_true",
-            help="display version information")
+    group.add_argument(
+        "-p", "--post", nargs=1,
+        help="create a new post with the title POST (if a file named POST "
+        "exists, it is moved to a new post instead)")
+    group.add_argument(
+        "--page", nargs=1,
+        help="create a new page with the title PAGE (if a file named PAGE "
+        "exists, it is moved to a new page instead)")
+    group.add_argument(
+        "-d", "--draft", nargs=1,
+        help="creates a new draft with the title DRAFT (if a file named DRAFT "
+        "exists, it is moved to a new draft instead)")
+    group.add_argument(
+        "--preview", nargs=1,
+        help="rebuilds the blog, including the draft PREVIEW, without "
+        "permanently promoting the draft to a post")
+    group.add_argument(
+        "-v", "--version", action="store_true",
+        help="display version information")
 
     parser.add_argument(
         '-t', '--template', action='store', default=None,
         help="specify a body template, defaults to page or post",
     )
-    parser.add_argument("--date", nargs=1,
-            help="optionally specify a date as 'YYYY/mm/dd' for the post, useful when "
-                 " migrating blogs; can only be used together with -p/--post")
+    parser.add_argument(
+        "--date", nargs=1,
+        help="optionally specify a date as 'YYYY/mm/dd' for the post, "
+        "useful when migrating blogs; can only be used together with "
+        "-p/--post")
 
     group = parser.add_mutually_exclusive_group()
     group.add_argument("-q", "--quiet", action="store_true", help="quiet mode")
-    group.add_argument("-f", "--filename", action="store_true",
-            help="output filename only - useful to pipe Tinkerer commands")
+    group.add_argument(
+        "-f", "--filename", action="store_true",
+        help="output filename only - useful to pipe Tinkerer commands")
 
     command = parser.parse_args(argv)
 
     output.init(command.quiet, command.filename)
 
     # tinkerer should be run from the blog root unless in setup mode or -v
-    if not command.setup and not command.version and not os.path.exists(paths.conf_file):
+    if (not command.setup and not command.version
+            and not os.path.exists(paths.conf_file)):
         output.write.error("Tinkerer must be run from your blog root "
-                    "(directory containing 'conf.py')")
+                           "(directory containing 'conf.py')")
         return -1
 
     post_date = None
@@ -198,16 +202,19 @@ def main(argv=None):
         try:
             post_date = datetime.strptime(command.date[0], "%Y/%m/%d")
         except:
-            output.write.error("Invalid post date: format should be YYYY/mm/dd")
+            output.write.error(
+                "Invalid post date: format should be YYYY/mm/dd"
+            )
             return -1
 
     if command.template:
         if not os.path.exists(os.path.join(paths.templates, command.template)):
-            output.write.error("The specified template does not exist. "
-                    " Make sure the template is placed inside the _templates"
-                    " subdirectory of your blog.")
+            output.write.error(
+                "The specified template does not exist. "
+                " Make sure the template is placed inside the _templates"
+                " subdirectory of your blog.")
             return -1
-    
+
     if command.setup:
         setup()
     elif command.build:

--- a/tinkerer/draft.py
+++ b/tinkerer/draft.py
@@ -15,7 +15,6 @@ import tinkerer
 from tinkerer import master, paths, utils, writer
 
 
-
 def create(title, template=None):
     '''
     Creates a new post draft.
@@ -24,24 +23,22 @@ def create(title, template=None):
     template = template or paths.post_template
 
     path = os.path.join(
-                    utils.get_path(
-                        paths.root, 
-                        "drafts"), 
-                    name + tinkerer.source_suffix)
+        utils.get_path(paths.root, "drafts"),
+        name + tinkerer.source_suffix,
+    )
 
     if os.path.exists(path):
         raise Exception("Draft '%s' already exists at '%s" %
                         (title, path))
 
     writer.render(template, path,
-            { "title"     : title,
-              "content"   : "",
-              "author"    : "default",
-              "categories": "none",
-              "tags"      : "none"})
+                  {"title":      title,
+                   "content":    "",
+                   "author":     "default",
+                   "categories": "none",
+                   "tags":       "none"})
 
     return path
-
 
 
 def move(path):

--- a/tinkerer/ext/__init__.py
+++ b/tinkerer/ext/__init__.py
@@ -8,4 +8,3 @@
     CONTRIBUTORS file)
     :license: FreeBSD, see LICENSE file
 '''
-

--- a/tinkerer/ext/aggregator.py
+++ b/tinkerer/ext/aggregator.py
@@ -12,7 +12,6 @@ import copy
 from tinkerer.ext.uistr import UIStr
 
 
-
 def make_aggregated_pages(app):
     '''
     Generates aggregated pages.
@@ -21,13 +20,13 @@ def make_aggregated_pages(app):
     posts_per_page = app.config.posts_per_page
 
     # get post groups
-    groups = [env.blog_posts[i:i+posts_per_page] for i in range(0, 
-                    len(env.blog_posts), posts_per_page)]
+    groups = [env.blog_posts[i:i+posts_per_page]
+              for i in range(0, len(env.blog_posts), posts_per_page)]
 
     # for each group
     for i, posts in enumerate(groups):
         # initialize context
-        context = { 
+        context = {
             "prev": {},
             "next": {},
             "posts": []
@@ -39,7 +38,6 @@ def make_aggregated_pages(app):
             metadata = copy.deepcopy(env.blog_metadata[post])
             context["posts"].append(metadata)
 
-
         # handle navigation
         if i == 0:
             # first page doesn't have prev link and its title is "Home"
@@ -50,7 +48,9 @@ def make_aggregated_pages(app):
             # following pages prev-link to previous page (titled as "Newer")
             pagename = "page%d" % (i + 1)
             context["prev"]["title"] = UIStr.NEWER
-            context["prev"]["link"] = "index.html" if i == 1 else "page%d.html" % i
+            context["prev"]["link"] = (
+                "index.html" if i == 1 else "page%d.html" % i
+            )
             context["title"] = UIStr.PAGE_FMT % (i + 1)
 
         if i == len(groups) - 1:
@@ -64,4 +64,3 @@ def make_aggregated_pages(app):
         context["archive_title"] = UIStr.BLOG_ARCHIVE
 
         yield (pagename, context, "aggregated.html")
-

--- a/tinkerer/ext/author.py
+++ b/tinkerer/ext/author.py
@@ -9,13 +9,11 @@
     :license: FreeBSD, see LICENSE file
 '''
 from sphinx.util.compat import Directive
-import tinkerer.utils
-
 
 
 class AuthorDirective(Directive):
     '''
-    Author directive. The directive is not rendered, just stored in the 
+    Author directive. The directive is not rendered, just stored in the
     metadata and passed to the templating engine.
     '''
     required_arguments = 0
@@ -31,9 +29,7 @@ class AuthorDirective(Directive):
         # store author in metadata
         author = " ".join(self.arguments)
         if author == "default":
-            author = env.config.author 
+            author = env.config.author
         env.blog_metadata[env.docname].author = author
 
         return []
-
-

--- a/tinkerer/ext/blog.py
+++ b/tinkerer/ext/blog.py
@@ -8,10 +8,9 @@
     CONTRIBUTORS file)
     :license: FreeBSD, see LICENSE file
 '''
-from tinkerer.ext import aggregator, author, filing, html5, metadata, patch, \
-                         readmore, rss, uistr
+from tinkerer.ext import (aggregator, author, filing, html5, metadata, patch,
+                          readmore, rss, uistr)
 import gettext
-
 
 
 def initialize(app):
@@ -43,15 +42,14 @@ def initialize(app):
             pass
 
     app.t = gettext.translation(
-                    "tinkerer",
-                    locale_dir,
-                    languages=languages,
-                    fallback=True)
+        "tinkerer",
+        locale_dir,
+        languages=languages,
+        fallback=True)
     app.t.install()
 
     # initialize localized strings
     uistr.UIStr(app)
-
 
 
 def source_read(app, docname, source):
@@ -61,13 +59,11 @@ def source_read(app, docname, source):
     metadata.get_metadata(app, docname)
 
 
-
 def env_updated(app, env):
     '''
     Processes data after environment is updated (all docs are read).
     '''
     metadata.process_metadata(app, env)
-
 
 
 def html_page_context(app, pagename, templatename, context, doctree):
@@ -76,7 +72,6 @@ def html_page_context(app, pagename, templatename, context, doctree):
     '''
     metadata.add_metadata(app, pagename, context)
     rss.add_rss(app, context)
-
 
 
 def collect_additional_pages(app):
@@ -99,16 +94,14 @@ def collect_additional_pages(app):
         yield (name, context, template)
 
 
-
 def html_collect_pages(app):
     '''
     Collect html pages and emit event
-    '''        
+    '''
     for name, context, template in collect_additional_pages(app):
         # emit event
         app.emit("html-collected-context", name, template, context)
         yield (name, context, template)
-
 
 
 def html_collected_context(app, name, template, context):
@@ -117,7 +110,6 @@ def html_collected_context(app, name, template, context):
     '''
     if template == "aggregated.html":
         patch.patch_aggregated_metadata(context)
-
 
 
 def setup(app):
@@ -140,16 +132,16 @@ def setup(app):
     # new directives
     app.add_directive("author", author.AuthorDirective)
     app.add_directive("comments", metadata.CommentsDirective)
-    app.add_directive("tags", 
-            filing.create_filing_directive("tags"))
-    app.add_directive("categories", 
-            filing.create_filing_directive("categories"))
+    app.add_directive("tags",
+                      filing.create_filing_directive("tags"))
+    app.add_directive("categories",
+                      filing.create_filing_directive("categories"))
     app.add_directive("more", readmore.InsertReadMoreLink)
- 
+
     # create a new Sphinx event which gets called when we generate aggregated
     # pages
     app._events["html-collected-context"] = "pagename, templatename, context"
- 
+
     # event handlers
     app.connect("builder-inited", initialize)
     app.connect("source-read", source_read)

--- a/tinkerer/ext/disqus.py
+++ b/tinkerer/ext/disqus.py
@@ -4,21 +4,18 @@
 
     Handler for `comments` directive using Disqus.
     Disqus shortname must be provided in `conf.py` as `disqus_shortname`.
-    
+
     :copyright: Copyright 2011-2014 by Vlad Riscutia and contributors (see
     CONTRIBUTORS file)
     :license: FreeBSD, see LICENSE file
 '''
-from sphinx.util.compat import Directive
-from docutils import nodes
 
-
+# flake8: noqa
 
 '''
 Disqus JS script file.
 '''
 DISQUS_SCRIPT = "_static/disqus.js"
-
 
 
 def create_thread(disqus_shortname, identifier):
@@ -35,7 +32,6 @@ def create_thread(disqus_shortname, identifier):
 '<noscript>Please enable JavaScript to view the '
 '   <a href=\"http://disqus.com/?ref_noscript\">comments powered by Disqus.</a>'
 '</noscript>' % (disqus_shortname, identifier))
-
 
 
 def enable_count(disqus_shortname):

--- a/tinkerer/ext/filing.py
+++ b/tinkerer/ext/filing.py
@@ -13,11 +13,10 @@ from tinkerer import utils
 from tinkerer.ext.uistr import UIStr
 
 
-
 def create_filing_directive(name):
     class FilingDirective(Directive):
         '''
-        Filing directive used to groups posts. The directive is not rendered, 
+        Filing directive used to groups posts. The directive is not rendered,
         just stored in the metadata and passed to the templating engine.
         '''
         required_arguments = 0
@@ -36,27 +35,26 @@ def create_filing_directive(name):
                     continue
 
                 if not item:
-                    env.warn(env.docname, "Empty string in '%s' directive" % (name,))
+                    env.warn(env.docname,
+                             "Empty string in '%s' directive" % (name,))
                     continue
 
                 if item not in env.filing[name]:
                     env.filing[name][item] = []
                 env.filing[name][item].append(env.docname)
                 env.blog_metadata[env.docname].filing[name].append(
-                        (utils.name_from_title(item), item))
+                    (utils.name_from_title(item), item))
 
             return []
 
     return FilingDirective
 
 
-
 def initialize(app):
     '''
     Initializes tags and categories.
     '''
-    app.builder.env.filing = { "tags": dict(), "categories": dict() }
-
+    app.builder.env.filing = {"tags": dict(), "categories": dict()}
 
 
 def make_archive_page(env, title, pagename, post_filter=None):
@@ -64,7 +62,7 @@ def make_archive_page(env, title, pagename, post_filter=None):
     Generates archive page with given title by applying the given filter to
     all posts and aggregating results by year.
     '''
-    context = { "title": title }
+    context = {"title": title}
     context["years"] = dict()
 
     for post in filter(post_filter, env.blog_posts):
@@ -76,16 +74,14 @@ def make_archive_page(env, title, pagename, post_filter=None):
     return (pagename, context, "archive.html")
 
 
-
 def make_archive(app):
     '''
     Generates blog archive including all posts.
     '''
     yield make_archive_page(
-                app.builder.env, 
-                UIStr.BLOG_ARCHIVE,
-                "archive")
-
+        app.builder.env,
+        UIStr.BLOG_ARCHIVE,
+        "archive")
 
 
 def make_tag_pages(app):
@@ -94,11 +90,11 @@ def make_tag_pages(app):
     '''
     env = app.builder.env
     for tag in env.filing["tags"]:
-        yield make_archive_page(env,
-                UIStr.TAGGED_WITH_FMT % tag,
-                "tags/" + utils.name_from_title(tag),
-                lambda post: post in env.filing["tags"][tag])
-
+        yield make_archive_page(
+            env,
+            UIStr.TAGGED_WITH_FMT % tag,
+            "tags/" + utils.name_from_title(tag),
+            lambda post: post in env.filing["tags"][tag])
 
 
 def make_category_pages(app):
@@ -107,8 +103,8 @@ def make_category_pages(app):
     '''
     env = app.builder.env
     for category in env.filing["categories"]:
-        yield make_archive_page(env,
-                UIStr.FILED_UNDER_FMT % category,
-                "categories/" + utils.name_from_title(category),
-                lambda post: post in env.filing["categories"][category])
-
+        yield make_archive_page(
+            env,
+            UIStr.FILED_UNDER_FMT % category,
+            "categories/" + utils.name_from_title(category),
+            lambda post: post in env.filing["categories"][category])

--- a/tinkerer/ext/html5.py
+++ b/tinkerer/ext/html5.py
@@ -11,13 +11,11 @@
 from sphinx.writers.html import HTMLTranslator
 
 
-
 def visit_desc_addname(self, node):
     '''
     Similar to Sphinx but using a <span> node instead of <tt>.
     '''
     self.body.append(self.starttag(node, 'span', '', CLASS='descclassname'))
-
 
 
 def depart_desc_addname(self, node):
@@ -27,7 +25,6 @@ def depart_desc_addname(self, node):
     self.body.append('</span>')
 
 
-
 def visit_desc_name(self, node):
     '''
     Similar to Sphinx but using a <span> node instead of <tt>.
@@ -35,13 +32,11 @@ def visit_desc_name(self, node):
     self.body.append(self.starttag(node, 'span', '', CLASS='descname'))
 
 
-
 def depart_desc_name(self, node):
     '''
     Similar to Sphinx but using a <span> node instead of <tt>.
     '''
     self.body.append('</span>')
-
 
 
 def visit_literal(self, node):
@@ -53,14 +48,12 @@ def visit_literal(self, node):
     self.protect_literal_text += 1
 
 
-
 def depart_literal(self, node):
     '''
     Similar to Sphinx but using a <span> node instead of <tt>.
     '''
     self.protect_literal_text -= 1
     self.body.append('</span>')
-
 
 
 def patch_translator():
@@ -73,4 +66,3 @@ def patch_translator():
     HTMLTranslator.depart_desc_name = depart_desc_name
     HTMLTranslator.visit_literal = visit_literal
     HTMLTranslator.depart_literal = depart_literal
-

--- a/tinkerer/ext/metadata.py
+++ b/tinkerer/ext/metadata.py
@@ -11,7 +11,6 @@
 '''
 import re
 import datetime
-import locale
 from functools import partial
 from sphinx.util.compat import Directive
 from babel.core import Locale
@@ -19,7 +18,6 @@ from babel.dates import format_date
 import tinkerer
 from tinkerer.ext.uistr import UIStr
 from tinkerer.utils import name_from_title
-
 
 
 def initialize(app):
@@ -34,6 +32,7 @@ class Metadata:
     Metadata associated with each post/page.
     '''
     num = 1
+
     def __init__(self):
         '''
         Initializes metadata with default values.
@@ -47,11 +46,10 @@ class Metadata:
         self.formatted_date_short = None
         self.body = None
         self.author = None
-        self.filing = { "tags": [], "categories": [] }
+        self.filing = {"tags": [], "categories": []}
         self.comments, self.comment_count = False, False
         self.num = Metadata.num
         Metadata.num += 1
-
 
 
 class CommentsDirective(Directive):
@@ -75,7 +73,6 @@ class CommentsDirective(Directive):
         return []
 
 
-
 def get_metadata(app, docname):
     '''
     Extracts metadata from a document.
@@ -93,8 +90,8 @@ def get_metadata(app, docname):
 
     # if it's a page
     if docname.startswith("pages/"):
-      metadata.is_page = True
-      return
+        metadata.is_page = True
+        return
 
     # posts are identified by ($YEAR)/($MONTH)/($DAY) paths
     match = re.match(r"\d{4}/\d{2}/\d{2}/", docname)
@@ -142,8 +139,9 @@ def process_metadata(app, env):
                 elif env.blog_metadata[doc].is_page:
                     env.blog_pages.append(doc)
 
-    env.blog_page_list = [("index", UIStr.HOME)] + [(page, env.titles[page].astext()) for page in env.blog_pages]
-
+    env.blog_page_list = [("index", UIStr.HOME)] + \
+                         [(page, env.titles[page].astext())
+                          for page in env.blog_pages]
 
 
 def add_metadata(app, pagename, context):
@@ -171,12 +169,13 @@ def add_metadata(app, pagename, context):
 
     # recent posts
     context["recent"] = [(post, env.titles[post].astext()) for post
-            in env.blog_posts[:20]]
+                         in env.blog_posts[:20]]
     # tags & categories
     tags = dict((t, 0) for t in env.filing["tags"])
     taglinks = dict((t, name_from_title(t)) for t in env.filing["tags"])
     categories = dict((c, 0) for c in env.filing["categories"])
-    catlinks = dict([(c, name_from_title(c)) for c in env.filing["categories"]])
+    catlinks = dict([(c, name_from_title(c))
+                     for c in env.filing["categories"]])
     for post in env.blog_posts:
         p = env.blog_metadata[post]
         for tag in p.filing["tags"]:

--- a/tinkerer/ext/patch.py
+++ b/tinkerer/ext/patch.py
@@ -11,13 +11,10 @@
     :license: FreeBSD, see LICENSE file
 '''
 from os import path
-import re
-import xml.dom.minidom
 
 import pyquery
 
 from tinkerer.ext.uistr import UIStr
-
 
 
 def patch_aggregated_metadata(context):
@@ -27,14 +24,14 @@ def patch_aggregated_metadata(context):
     for metadata in context["posts"]:
         metadata.body = patch_links(
             metadata.body,
-            metadata.link[:11], # first 11 characters is path (YYYY/MM/DD/)
-            metadata.link[11:], # following characters represent filename
+            metadata.link[:11],  # first 11 characters is path (YYYY/MM/DD/)
+            metadata.link[11:],  # following characters represent filename
             True)      # hyperlink title to post
         metadata.body = strip_xml_declaration(metadata.body)
 
 
-
-def patch_links(body, docpath, docname=None, link_title=False, replace_read_more_link=True):
+def patch_links(body, docpath, docname=None, link_title=False,
+                replace_read_more_link=True):
     '''
     Parses the document body and calls patch_node from the document root
     to fix hyperlinks. Also hyperlinks document title. Returns resulting
@@ -53,17 +50,15 @@ def patch_links(body, docpath, docname=None, link_title=False, replace_read_more
         return body
 
 
-
 def hyperlink_title(body, docpath, docname):
     """
     Hyperlink titles by embedding appropriate a tag inside
     h1 tags (which should only be post titles).
     """
     body = body.replace("<h1>", '<h1><a href="%s.html">' %
-            (docpath + docname), 1)
+                        (docpath + docname), 1)
     body = body.replace("</h1>", "</a></h1>", 1)
     return body
-
 
 
 def make_read_more_link(body, docpath, docname):
@@ -79,13 +74,12 @@ def make_read_more_link(body, docpath, docname):
     return doc.html()
 
 
-
 def collapse_path(path_url):
     '''
-    Normalize relative path and patch protocol prefix and Windows path separator
+    Normalize relative path and patch protocol prefix
+    and Windows path separator
     '''
     return path.normpath(path_url).replace("\\", "/").replace(":/", "://")
-
 
 
 def patch_node(node, docpath, docname=None):
@@ -99,7 +93,7 @@ def patch_node(node, docpath, docname=None):
     for anchor in node.find('a'):
         ref = anchor.get('href')
         # skip anchor links <a name="anchor1"></a>, <a name="more"/>
-        if ref != None:
+        if ref is not None:
             # patch links only - either starting with "../" or having
             # "internal" class
             is_relative = ref.startswith("../")
@@ -128,4 +122,3 @@ def strip_xml_declaration(body):
     Remove XML declaration from document body.
     """
     return body.replace('<?xml version="1.0" ?>', '')
-

--- a/tinkerer/ext/readmore.py
+++ b/tinkerer/ext/readmore.py
@@ -13,7 +13,6 @@ from docutils import nodes
 from sphinx.util.compat import Directive
 
 
-
 class InsertReadMoreLink(Directive):
     '''
     Sphinx extension for inserting a "Read more..." link.
@@ -22,7 +21,5 @@ class InsertReadMoreLink(Directive):
     has_content = True
     required_arguments = 0
 
-
     def run(self):
         return [nodes.raw("", '<div id="more"> </div>', format="html")]
-

--- a/tinkerer/ext/rss.py
+++ b/tinkerer/ext/rss.py
@@ -2,20 +2,18 @@
     rss
     ~~~
 
-    RSS feed generator for blog. 
+    RSS feed generator for blog.
 
     :copyright: Copyright 2011-2014 by Vlad Riscutia and contributors (see
     CONTRIBUTORS file)
     :license: FreeBSD, see LICENSE file
 '''
-import cgi
 import email.utils
 import time
 
 import pyquery
 
 from tinkerer.ext import patch
-from tinkerer import utils
 
 
 def remove_header_link(body):
@@ -62,28 +60,31 @@ def make_feed_context(app, feed_name, posts):
         link = "%s%s.html" % (app.config.website, post)
 
         timestamp = email.utils.formatdate(
-                time.mktime(env.blog_metadata[post].date.timetuple()),
-                localtime=True)
+            time.mktime(env.blog_metadata[post].date.timetuple()),
+            localtime=True)
 
-        categories = [category[1] for category in env.blog_metadata[post].filing["categories"]]
+        categories = [category[1] for category in
+                      env.blog_metadata[post].filing["categories"]]
 
         description = patch.strip_xml_declaration(
             patch.patch_links(
                 env.blog_metadata[post].body,
-                app.config.website + post[:11], # first 11 characters is path (YYYY/MM/DD/)
-                post[11:], # following characters represent filename
+                # first 11 characters of post is the path (YYYY/MM/DD/)
+                app.config.website + post[:11],
+                # following characters represent filename
+                post[11:],
                 replace_read_more_link=not app.config.rss_generate_full_posts,
             ),
         )
         description = remove_header_link(description)
 
         context["items"].append({
-                    "title": env.titles[post].astext(),
-                    "link": link,
-                    "description": description,
-                    "categories": categories,
-                    "pubDate": timestamp
-                })
+            "title": env.titles[post].astext(),
+            "link": link,
+            "description": description,
+            "categories": categories,
+            "pubDate": timestamp
+        })
 
     # feed metadata
     if feed_name:

--- a/tinkerer/ext/uistr.py
+++ b/tinkerer/ext/uistr.py
@@ -17,13 +17,11 @@ except:
     import __builtin__
 
 
-
 # check whether unicode builtin exists, otherwise strings are unicode by
 # default so it can be stubbed
 if "unicode" not in __builtin__.__dict__:
     def unicode(ret, ignore):
         return ret
-
 
 
 class UIStr:
@@ -41,10 +39,14 @@ class UIStr:
         UIStr.CATEGORIES = unicode(_("Categories"), "utf-8")
         UIStr.TIMESTAMP_FMT = unicode(_('MMMM dd, yyyy'), "utf-8")
         UIStr.TIMESTAMP_FMT_SHORT = unicode(_('MMM dd'), "utf-8")
-        UIStr.TAGGED_WITH_FMT = unicode(_('Posts tagged with <span class="title_tag">%s</span>'), "utf-8")
-        UIStr.FILED_UNDER_FMT = unicode(_('Filed under <span class="title_category">%s</span>'), "utf-8")
+        UIStr.TAGGED_WITH_FMT = unicode(
+            _('Posts tagged with <span class="title_tag">%s</span>'), "utf-8")
+        UIStr.FILED_UNDER_FMT = unicode(
+            _('Filed under <span class="title_category">%s</span>'), "utf-8")
         UIStr.NEWER = unicode(_("Newer"), "utf-8")
         UIStr.OLDER = unicode(_("Older"), "utf-8")
         UIStr.PAGE_FMT = unicode(_("Page %d"), "utf-8")
         UIStr.READ_MORE = unicode(_("Read more..."), "utf-8")
-        UIStr.MAIL_HIDDEN_BY_JAVASCRIPT = unicode(_("Javascript must be enabled to see this e-mail address"), "utf-8")
+        UIStr.MAIL_HIDDEN_BY_JAVASCRIPT = unicode(
+            _("Javascript must be enabled to see this e-mail address"),
+            "utf-8")

--- a/tinkerer/master.py
+++ b/tinkerer/master.py
@@ -11,7 +11,6 @@
 from tinkerer import paths
 
 
-
 def read_master():
     '''
     Reads master file into a list.
@@ -20,14 +19,12 @@ def read_master():
         return f.readlines()
 
 
-
 def write_master(lines):
     '''
     Overwrites master file with given lines.
     '''
     with open(paths.master_file, "w") as f:
         f.writelines(lines)
-
 
 
 def prepend_doc(docname):
@@ -48,7 +45,6 @@ def prepend_doc(docname):
     write_master(lines)
 
 
-
 def append_doc(docname):
     '''
     Appends document at the end of the TOC.
@@ -58,9 +54,12 @@ def append_doc(docname):
     # find second blank line after maxdepth directive
     blank, line_no = 0, 0
     for line_no, line in enumerate(read_master()):
-        if blank == 3: break
-        if "maxdepth" in line: blank = 1
-        if blank and line == "\n": blank += 1
+        if blank == 3:
+            break
+        if "maxdepth" in line:
+            blank = 1
+        if blank and line == "\n":
+            blank += 1
 
     lines.insert(line_no, "   %s\n" % docname)
 
@@ -73,11 +72,13 @@ def exists_doc(docname):
     '''
     return ("   %s\n" % docname) in read_master()
 
+
 def remove_doc(docname):
     '''
     Removes document from the TOC.
     '''
     # rewrite file filtering line containing docname
     write_master(filter(
-            lambda line: line != "   %s\n" % docname,
-            read_master()))
+        lambda line: line != "   %s\n" % docname,
+        read_master())
+    )

--- a/tinkerer/output.py
+++ b/tinkerer/output.py
@@ -24,7 +24,6 @@ filename = logging.getLogger("filename")
 quiet = False
 
 
-
 def init(quiet_mode, filename_only):
     """
     Initialize output based on quiet/filename-only flags
@@ -50,4 +49,3 @@ def init(quiet_mode, filename_only):
     else:
         # otherwise display INFO
         write.setLevel(logging.INFO)
-

--- a/tinkerer/page.py
+++ b/tinkerer/page.py
@@ -14,7 +14,6 @@ import tinkerer
 from tinkerer import master, paths, utils, writer
 
 
-
 class Page():
     '''
     The class provides methods to create a new page and insert it into the
@@ -22,7 +21,7 @@ class Page():
     '''
     def __init__(self, title=None, path=None):
         '''
-        Determines page filename based on title or given path and creates the 
+        Determines page filename based on title or given path and creates the
         path to the page if it doesn't already exist.
         '''
         self.title = title
@@ -35,14 +34,11 @@ class Page():
 
         # create page directory if it doesn't exist and get page path
         self.path = os.path.join(
-                            utils.get_path(
-                                paths.root, 
-                                "pages"), 
-                            self.name) + tinkerer.source_suffix
+            utils.get_path(paths.root, "pages"),
+            self.name) + tinkerer.source_suffix
 
         # docname as it should appear in TOC
         self.docname = "pages/" + self.name
-
 
     def write(self, content="", template=None):
         '''
@@ -50,9 +46,8 @@ class Page():
         '''
         template = template or paths.page_template
         writer.render(template, self.path,
-                { "title": self.title,
-                  "content": content })
-
+                      {"title": self.title,
+                       "content": content})
 
 
 def create(title, template=None):
@@ -67,7 +62,6 @@ def create(title, template=None):
     if not master.exists_doc(page.docname):
         master.append_doc(page.docname)
     return page
-
 
 
 def move(path, date=None):

--- a/tinkerer/paths.py
+++ b/tinkerer/paths.py
@@ -43,7 +43,8 @@ def set_paths(root_path="."):
     blog = os.path.join(root, "blog")
     doctree = os.path.join(blog, "doctrees")
     html = os.path.join(blog, "html")
-    master_file = os.path.join(root, tinkerer.master_doc + tinkerer.source_suffix)
+    master_file = os.path.join(root,
+                               tinkerer.master_doc + tinkerer.source_suffix)
     index_file = os.path.join(root, "index.html")
     conf_file = os.path.join(root, "conf.py")
 

--- a/tinkerer/post.py
+++ b/tinkerer/post.py
@@ -8,17 +8,15 @@
     CONTRIBUTORS file)
     :license: FreeBSD, see LICENCE file
 '''
-from datetime import datetime
 import os
 import shutil
 import tinkerer
 from tinkerer import master, paths, utils, writer
 
 
-
 class Post():
     '''
-    The class provides methods to create a new post and insert it into the 
+    The class provides methods to create a new post and insert it into the
     master document.
     '''
 
@@ -40,19 +38,17 @@ class Post():
 
         # create post directory if it doesn't exist and get post path
         self.path = os.path.join(
-                            utils.get_path(
-                                    paths.root,
-                                    self.year,
-                                    self.month,
-                                    self.day),
-                            self.name) + tinkerer.source_suffix
+            utils.get_path(
+                paths.root,
+                self.year,
+                self.month,
+                self.day),
+            self.name) + tinkerer.source_suffix
 
         # docname as it should appear in TOC
         self.docname = "/".join([self.year, self.month, self.day, self.name])
 
-
-
-    def write(self, content="", author="default", 
+    def write(self, content="", author="default",
               categories="none", tags="none",
               template=None):
         '''
@@ -60,12 +56,11 @@ class Post():
         '''
         template = template or paths.post_template
         writer.render(template, self.path,
-               { "title"     : self.title,
-                 "content"   : content,
-                 "author"    : author,
-                 "categories": categories,
-                 "tags"      : tags})
-
+                      {"title":      self.title,
+                       "content":    content,
+                       "author":     author,
+                       "categories": categories,
+                       "tags":       tags})
 
 
 def create(title, date=None, template=None):
@@ -83,7 +78,6 @@ def create(title, date=None, template=None):
     return post
 
 
-
 def move(path, date=None):
     '''
     Moves a post given its path.
@@ -96,4 +90,3 @@ def move(path, date=None):
     if not master.exists_doc(post.docname):
         master.prepend_doc(post.docname)
     return post
-

--- a/tinkerer/utils.py
+++ b/tinkerer/utils.py
@@ -19,8 +19,8 @@ UNICODE_ALNUM_PTN = re.compile(r"[\W_]+", re.U)
 
 def name_from_title(title):
     '''
-    Returns a doc name from a title by replacing all groups of 
-    characters which are not alphanumeric or '_' with the word 
+    Returns a doc name from a title by replacing all groups of
+    characters which are not alphanumeric or '_' with the word
     separator character.
     '''
     try:
@@ -28,9 +28,7 @@ def name_from_title(title):
     except:
         word_sep = "_"
 
-    return UNICODE_ALNUM_PTN.sub(word_sep, title
-        ).lower().strip(word_sep)
-
+    return UNICODE_ALNUM_PTN.sub(word_sep, title).lower().strip(word_sep)
 
 
 def name_from_path(path):
@@ -39,7 +37,6 @@ def name_from_path(path):
     extension.
     '''
     return os.path.splitext(os.path.basename(path))[0]
-
 
 
 def get_path(*args):
@@ -52,7 +49,6 @@ def get_path(*args):
     return path
 
 
-
 def split_date(date=None):
     '''
     Splits a date into formatted year, month and day strings. If not date is
@@ -62,7 +58,6 @@ def split_date(date=None):
         date = datetime.datetime.today()
 
     return "%04d" % date.year, "%02d" % date.month, "%02d" % date.day
-
 
 
 def get_conf():

--- a/tinkerer/writer.py
+++ b/tinkerer/writer.py
@@ -17,10 +17,10 @@ from tinkerer import paths, utils
 
 # jinja environment
 env = Environment(loader=ChoiceLoader([
-        # first choice is _templates subdir from blog root
-        FileSystemLoader(paths.templates),
-        # if template is not there, use tinkerer builtin
-        PackageLoader("tinkerer", "__templates")]))
+    # first choice is _templates subdir from blog root
+    FileSystemLoader(paths.templates),
+    # if template is not there, use tinkerer builtin
+    PackageLoader("tinkerer", "__templates")]))
 
 
 def render(template, destination, context={}, safe=False):
@@ -29,7 +29,6 @@ def render(template, destination, context={}, safe=False):
     '''
     with open(destination, "wb") as dest:
         dest.write(env.get_template(template).render(context).encode("utf8"))
-
 
 
 def render_safe(template, destination, context={}):
@@ -46,7 +45,6 @@ def render_safe(template, destination, context={}):
     return True
 
 
-
 def write_master_file():
     '''
     Writes the blog master document.
@@ -54,13 +52,11 @@ def write_master_file():
     return render_safe("master.rst", paths.master_file)
 
 
-
 def write_index_file():
     '''
     Writes the root index.html file.
     '''
     return render_safe("index.html", paths.index_file)
-
 
 
 '''
@@ -72,15 +68,14 @@ DEFAULT_EXTENSIONS = [
 ]
 
 
-
 def write_conf_file(extensions=DEFAULT_EXTENSIONS, theme="flat"):
     '''
     Writes the Sphinx configuration file.
     '''
-    return render_safe("conf.py", paths.conf_file,
-                {"extensions": ", ".join(["'%s'" % ext for ext in extensions]),
-                 "theme": theme })
-
+    return render_safe(
+        "conf.py", paths.conf_file,
+        {"extensions": ", ".join(["'%s'" % ext for ext in extensions]),
+         "theme": theme})
 
 
 def copy_templates():
@@ -88,11 +83,12 @@ def copy_templates():
     Copies Tinkerer post and page templates to blog _templates directory.
     '''
     for template in [paths.post_template, paths.page_template]:
-        if not os.path.exists(os.path.join(paths.root, "_templates", template)):
+        if not os.path.exists(os.path.join(paths.root, "_templates",
+                                           template)):
             shutil.copy(
                 os.path.join(paths.__internal_templates_abs_path, template),
-                    os.path.join(paths.root, "_templates"))
-
+                os.path.join(paths.root, "_templates")
+            )
 
 
 def setup_blog():
@@ -106,4 +102,3 @@ def setup_blog():
     write_master_file()
     write_index_file()
     return write_conf_file()
-

--- a/tinkertest/__init__.py
+++ b/tinkertest/__init__.py
@@ -1,2 +1,1 @@
 # Dummy file to make this a module
-

--- a/tinkertest/test_categories.py
+++ b/tinkertest/test_categories.py
@@ -11,7 +11,6 @@
 import datetime
 import os
 from tinkerer import paths, post
-import unittest
 from tinkertest import utils
 
 
@@ -22,12 +21,13 @@ class TestCategories(utils.BaseTinkererTest):
 
         # create some posts with categories
 
-        # missing category for Post1 ("cateogry #1,") should work, just issue a warning
+        # missing category for Post1 ("cateogry #1,") should work,
+        # just issue a warning
         for new_post in [("Post1", "category #1,"),
                          ("Post2", "category #2"),
                          ("Post12", "category #1, category #2")]:
             post.create(new_post[0], datetime.date(2010, 10, 1)).write(
-                    categories=new_post[1])
+                categories=new_post[1])
 
         utils.hook_extension("test_categories")
         self.build()
@@ -38,23 +38,30 @@ def build_finished(app, exception):
     blog_categories = app.builder.env.filing["categories"]
 
     # check collected categories
-    utils.test.assertEquals(set(["category #1", "category #2"]), set(blog_categories))
+    utils.test.assertEquals(set(["category #1", "category #2"]),
+                            set(blog_categories))
 
     # check categories
-    for result in [(set(["2010/10/01/post1", "2010/10/01/post12"]), "category #1"),
-                   (set(["2010/10/01/post2", "2010/10/01/post12"]), "category #2")]:
+    for result in [(set(["2010/10/01/post1", "2010/10/01/post12"]),
+                    "category #1"),
+                   (set(["2010/10/01/post2", "2010/10/01/post12"]),
+                    "category #2")]:
         utils.test.assertEquals(result[0], set(blog_categories[result[1]]))
 
     # check post metadata
     for result in [([("category__1", "category #1")], "2010/10/01/post1"),
                    ([("category__2", "category #2")], "2010/10/01/post2"),
-                   ([("category__1", "category #1"), ("category__2", "category #2")], "2010/10/01/post12")]:
-        utils.test.assertEquals(result[0], 
-                app.builder.env.blog_metadata[result[1]].filing["categories"])
+                   ([("category__1", "category #1"),
+                     ("category__2", "category #2")], "2010/10/01/post12")]:
+        utils.test.assertEquals(
+            result[0],
+            app.builder.env.blog_metadata[result[1]].filing["categories"])
 
     # check category pages were generated
     for page in ["category__1.html", "category__2.html"]:
-        utils.test.assertTrue(os.path.exists(os.path.join(paths.html, "categories", page)))
+        utils.test.assertTrue(os.path.exists(os.path.join(paths.html,
+                                                          "categories",
+                                                          page)))
 
 
 # extension setup
@@ -62,4 +69,3 @@ def setup(app):
     if utils.is_module(app):
         return
     app.connect("build-finished", build_finished)
-    

--- a/tinkertest/test_cmdline.py
+++ b/tinkertest/test_cmdline.py
@@ -29,17 +29,15 @@ class TestCmdLine(utils.BaseTinkererTest):
         logging.disable(logging.CRITICAL)
         utils.setup()
 
-
     # re-enable logging
     def tearDown(self):
         logging.disable(logging.NOTSET)
         utils.cleanup()
 
-
     # test blog setup
     def test_setup(self):
-        # blog is setup as part of test setup, tear it down and re-create it via
-        # cmdline
+        # blog is setup as part of test setup, tear it down and
+        # re-create it via cmdline
         self.tearDown()
         cmdline.main(["--setup", "--quiet"])
 
@@ -54,7 +52,6 @@ class TestCmdLine(utils.BaseTinkererTest):
                 tinkerer.master_doc + ".rst"
             ]))
 
-
     # test post from title
     def test_post_from_title(self):
         cmdline.main(["--post", "My Test Post", "--quiet"])
@@ -62,11 +59,11 @@ class TestCmdLine(utils.BaseTinkererTest):
         # this might fail at midnight :P
         year, month, day = tinkerer.utils.split_date()
 
-        file_path = os.path.join(utils.TEST_ROOT, year, month, day, "my_test_post.rst")
+        file_path = os.path.join(utils.TEST_ROOT, year, month, day,
+                                 "my_test_post.rst")
 
         # assert file exists
         self.assertTrue(os.path.exists(file_path))
-
 
     # test post from existing file
     def test_post_from_path(self):
@@ -81,35 +78,37 @@ class TestCmdLine(utils.BaseTinkererTest):
         # this might also fail at midnight :P
         year, month, day = tinkerer.utils.split_date()
 
-        file_path = os.path.join(utils.TEST_ROOT, year, month, day, "draft_post.rst")
+        file_path = os.path.join(utils.TEST_ROOT, year, month, day,
+                                 "draft_post.rst")
 
         # assert file exists and check content
         self.assertTrue(os.path.exists(file_path))
         with open(file_path, "r") as f:
             self.assertEquals("Content", f.read())
 
-
     # test post with explicit date
     def test_post_with_date(self):
         cmdline.main(["--post", "Dated Post", "--date", "2011/11/20"])
 
-        file_path = os.path.join(utils.TEST_ROOT, "2011/11/20", "dated_post.rst")
+        file_path = os.path.join(utils.TEST_ROOT, "2011/11/20",
+                                 "dated_post.rst")
 
         # assert file exists
         self.assertTrue(os.path.exists(file_path))
 
-
     # test date is only allowed with post argument
     def test_date_only_on_post(self):
-        self.assertNotEqual(0,
-                cmdline.main(["--page", "Test Page", "--date", "2011/11/20"]))
+        self.assertNotEqual(
+            0,
+            cmdline.main(["--page", "Test Page", "--date", "2011/11/20"]))
 
-        self.assertNotEqual(0,
-                cmdline.main(["--draft", "Test Draft", "--date", "2011/11/20"]))
+        self.assertNotEqual(
+            0,
+            cmdline.main(["--draft", "Test Draft", "--date", "2011/11/20"]))
 
-        self.assertNotEqual(0,
-                cmdline.main(["--build", "--date", "2011/11/20"]))
-
+        self.assertNotEqual(
+            0,
+            cmdline.main(["--build", "--date", "2011/11/20"]))
 
     # test page from title
     def test_page_from_title(self):
@@ -120,9 +119,8 @@ class TestCmdLine(utils.BaseTinkererTest):
         # assert file exsits
         self.assertTrue(os.path.exists(file_path))
 
-
     # test page from existing file
-    def test_post_from_path(self):
+    def test_post_from_existing_file(self):
         # create file
         draft_file = os.path.join(utils.TEST_ROOT, "drafts", "draft_page.rst")
 
@@ -138,7 +136,6 @@ class TestCmdLine(utils.BaseTinkererTest):
         with open(file_path, "r") as f:
             self.assertEquals("Content", f.read())
 
-
     # test draft
     def test_draft(self):
         cmdline.main(["--draft", "My Draft", "--quiet"])
@@ -148,19 +145,19 @@ class TestCmdLine(utils.BaseTinkererTest):
         # assert draft was created
         self.assertTrue(os.path.exists(file_path))
 
-
     # test missing template
     def test_missing_template(self):
         # creating a post with a missing template file should fail
         self.assertNotEqual(
             0,
-            cmdline.main(["--post", "test", "--template", "missing", "--quiet"]))
-
+            cmdline.main(["--post", "test", "--template", "missing",
+                          "--quiet"])
+        )
 
     # test build
     def test_build(self):
         # create a new post
-        new_post = post.create("My Post", datetime.date(2010, 10, 1))
+        post.create("My Post", datetime.date(2010, 10, 1))
 
         self.build()
 
@@ -169,26 +166,28 @@ class TestCmdLine(utils.BaseTinkererTest):
             os.path.join(utils.TEST_ROOT, "blog", "html", "2010",
                          "10", "01", "my_post.html")))
 
-
     # ensure tinkerer only runs from blog root (dir containing conf.py) except
     # when running setup
     def test_root_only(self):
         # remove "conf.py" created by test setup
         os.remove(os.path.join(paths.root, "conf.py"))
 
-        self.assertNotEqual(0,
-                cmdline.main(["--page", "Test Post", "--quiet"]))
+        self.assertNotEqual(
+            0,
+            cmdline.main(["--page", "Test Post", "--quiet"]))
 
-        self.assertNotEqual(0,
-                cmdline.main(["--post", "Test Page", "--quiet"]))
+        self.assertNotEqual(
+            0,
+            cmdline.main(["--post", "Test Page", "--quiet"]))
 
-        self.assertNotEqual(0,
-                cmdline.main(["--build", "--quiet"]))
+        self.assertNotEqual(
+            0,
+            cmdline.main(["--build", "--quiet"]))
 
         # setup should work fine from anywhere
-        self.assertEqual(0,
-                cmdline.main(["--setup", "--quiet"]))
-
+        self.assertEqual(
+            0,
+            cmdline.main(["--setup", "--quiet"]))
 
     def test_filename_only(self):
         # hook up test log handler
@@ -204,4 +203,3 @@ class TestCmdLine(utils.BaseTinkererTest):
 
         # output should be `conf.py`
         self.assertEquals("conf.py", test_stream.getvalue().strip())
-

--- a/tinkertest/test_disqus.py
+++ b/tinkertest/test_disqus.py
@@ -17,7 +17,7 @@ from tinkertest import utils
 
 # test case
 class TestDisqus(utils.BaseTinkererTest):
-    #test disqus extension
+    # test disqus extension
     def test_disqus(self):
         TEST_SHORTNAME = "test_shortname"
 
@@ -26,7 +26,7 @@ class TestDisqus(utils.BaseTinkererTest):
         conf_text = open(conf_path, "r").read()
 
         open(conf_path, "w").write(
-            conf_text.replace("disqus_shortname = None", 
+            conf_text.replace("disqus_shortname = None",
                               'disqus_shortname = "%s"' % TEST_SHORTNAME))
 
         # create a post
@@ -38,15 +38,15 @@ class TestDisqus(utils.BaseTinkererTest):
         self.build()
 
         # ensure disqus script is added to html output
-        output = os.path.join(utils.TEST_ROOT, 
-            "blog", "html", "2010", "10", "01", "post1.html")
+        output = os.path.join(utils.TEST_ROOT,
+                              "blog", "html", "2010", "10", "01", "post1.html")
         output_html = open(output, "r").read()
 
         self.assertTrue(
             disqus.create_thread(TEST_SHORTNAME, POST_ID) in output_html)
 
-        output = os.path.join(utils.TEST_ROOT, 
-            "blog", "html", "index.html")
+        output = os.path.join(utils.TEST_ROOT,
+                              "blog", "html", "index.html")
         output_html = open(output, "r").read()
 
         # ensure script to enable comment count is added to aggregated page
@@ -56,4 +56,3 @@ class TestDisqus(utils.BaseTinkererTest):
         # ensure comment count is added to aggregated page
         self.assertTrue(
             disqus.get_count(POST_LINK, POST_ID) in output_html)
-

--- a/tinkertest/test_draft.py
+++ b/tinkertest/test_draft.py
@@ -24,14 +24,13 @@ class TestDraft(utils.BaseTinkererTest):
         new_draft = draft.create("My Draft")
 
         self.assertEquals(
-                os.path.abspath(os.path.join(
-                                    utils.TEST_ROOT,
-                                    "drafts",
-                                    "my_draft.rst")),
-                new_draft)
+            os.path.abspath(os.path.join(
+                utils.TEST_ROOT,
+                "drafts",
+                "my_draft.rst")),
+            new_draft)
 
         self.assertTrue(os.path.exists(new_draft))
-
 
     # test moving draft from existing files
     def test_move(self):
@@ -45,7 +44,7 @@ class TestDraft(utils.BaseTinkererTest):
         self.assertTrue("   %s\n" % new_page.docname in lines)
 
         new_draft = draft.move(os.path.join(
-                            utils.TEST_ROOT, "pages", "a_page.rst"))
+            utils.TEST_ROOT, "pages", "a_page.rst"))
         self.assertTrue(os.path.exists(new_draft))
 
         # page should no longer be in TOC
@@ -54,14 +53,13 @@ class TestDraft(utils.BaseTinkererTest):
         self.assertFalse("   %s\n" % new_page.docname in lines)
 
         new_draft = draft.move(os.path.join(
-                            utils.TEST_ROOT, "2010", "10", "01", "a_post.rst"))
+            utils.TEST_ROOT, "2010", "10", "01", "a_post.rst"))
         self.assertTrue(os.path.exists(new_draft))
 
         # post should no longer be in TOC either
         lines = master.read_master()
         self.assertFalse("   %s\n" % new_post.docname in lines)
         self.assertFalse("   %s\n" % new_page.docname in lines)
-
 
     # test draft preview
     def test_preview(self):
@@ -80,12 +78,10 @@ class TestDraft(utils.BaseTinkererTest):
         self.assertEqual(
             0,
             cmdline.main(["--preview", new_draft, "-q"]))
-        
+
         # draft should not be in TOC
         for line in master.read_master():
             self.assertFalse("draft" in line)
-
-
 
     # test content
     def test_content(self):
@@ -94,16 +90,17 @@ class TestDraft(utils.BaseTinkererTest):
 
         # check expected empty post content
         with open(new_draft) as f:
-            self.assertEquals(f.readlines(),
-                    ["My Draft\n",
-                     "========\n",
-                     "\n",
-                     "\n",
-                     "\n",
-                     ".. author:: default\n",
-                     ".. categories:: none\n",
-                     ".. tags:: none\n",
-                     ".. comments::\n"])
+            self.assertEquals(
+                f.readlines(),
+                ["My Draft\n",
+                 "========\n",
+                 "\n",
+                 "\n",
+                 "\n",
+                 ".. author:: default\n",
+                 ".. categories:: none\n",
+                 ".. tags:: none\n",
+                 ".. comments::\n"])
 
     @mock.patch('tinkerer.writer.render')
     def test_create_without_template(self, render):

--- a/tinkertest/test_master.py
+++ b/tinkertest/test_master.py
@@ -16,23 +16,20 @@ from tinkertest import utils
 class TestMaster(utils.BaseTinkererTest):
     # head and tail of master doc checked in each test
     MASTER_HEAD = [
-            "Sitemap\n",
-            "=======\n",
-            "\n",
-            ".. toctree::\n",
-            "   :maxdepth: 1\n",
-            "\n"]
-
+        "Sitemap\n",
+        "=======\n",
+        "\n",
+        ".. toctree::\n",
+        "   :maxdepth: 1\n",
+        "\n"]
 
     MASTER_TAIL = ["\n"]
-
 
     # validate master doc created by setup
     def test_setup(self):
         self.assertEquals(
-                TestMaster.MASTER_HEAD + TestMaster.MASTER_TAIL,
-                master.read_master())
-
+            TestMaster.MASTER_HEAD + TestMaster.MASTER_TAIL,
+            master.read_master())
 
     # test appending at the end of the TOC
     def test_append(self):
@@ -42,21 +39,19 @@ class TestMaster(utils.BaseTinkererTest):
 
         # first doc should be appendend in the correct place
         self.assertEquals(
-                    TestMaster.MASTER_HEAD + 
-                    ["   %s\n" % new_docs[0]] + 
-                    TestMaster.MASTER_TAIL,
-                master.read_master())
+            TestMaster.MASTER_HEAD +
+            ["   %s\n" % new_docs[0]] +
+            TestMaster.MASTER_TAIL,
+            master.read_master())
 
         master.append_doc(new_docs[1])
 
         # second doc should be appended in the correct place
         self.assertEquals(
-                    TestMaster.MASTER_HEAD +
-                    ["   %s\n" % new_docs[0], "   %s\n" % new_docs[1]] +
-                    TestMaster.MASTER_TAIL,
-                master.read_master())
-
-
+            TestMaster.MASTER_HEAD +
+            ["   %s\n" % new_docs[0], "   %s\n" % new_docs[1]] +
+            TestMaster.MASTER_TAIL,
+            master.read_master())
 
     # test prepending at the beginning of the TOC
     def test_prepend(self):
@@ -66,20 +61,19 @@ class TestMaster(utils.BaseTinkererTest):
         master.prepend_doc(new_docs[0])
 
         self.assertEquals(
-                    TestMaster.MASTER_HEAD +
-                    ["   %s\n" % new_docs[0]] +
-                    TestMaster.MASTER_TAIL,
-                master.read_master())
+            TestMaster.MASTER_HEAD +
+            ["   %s\n" % new_docs[0]] +
+            TestMaster.MASTER_TAIL,
+            master.read_master())
 
         master.prepend_doc(new_docs[1])
 
         # order should be second doc then first doc
         self.assertEquals(
-                    TestMaster.MASTER_HEAD +
-                    ["   %s\n" % new_docs[1], "   %s\n" % new_docs[0]] +
-                    TestMaster.MASTER_TAIL,
-                master.read_master())
-
+            TestMaster.MASTER_HEAD +
+            ["   %s\n" % new_docs[1], "   %s\n" % new_docs[0]] +
+            TestMaster.MASTER_TAIL,
+            master.read_master())
 
     # test removing from the TOC
     def test_remove(self):
@@ -94,8 +88,7 @@ class TestMaster(utils.BaseTinkererTest):
             new_docs.remove(doc_to_remove)
 
             self.assertEquals(
-                        TestMaster.MASTER_HEAD +
-                        ["   %s\n" % doc for doc in new_docs] +
-                        TestMaster.MASTER_TAIL,
-                    master.read_master())
-
+                TestMaster.MASTER_HEAD +
+                ["   %s\n" % doc for doc in new_docs] +
+                TestMaster.MASTER_TAIL,
+                master.read_master())

--- a/tinkertest/test_metadata.py
+++ b/tinkertest/test_metadata.py
@@ -45,7 +45,7 @@ def build_finished(app, exception):
 
     # body should contain the whole 100 word string
     utils.test.assertTrue(" ".join("a" * 100) in
-            env.blog_metadata[env.blog_posts[0]].body)
+                          env.blog_metadata[env.blog_posts[0]].body)
 
 
 # extension setup

--- a/tinkertest/test_ordering.py
+++ b/tinkertest/test_ordering.py
@@ -9,7 +9,6 @@
     :license: FreeBSD, see LICENSE file
 '''
 import datetime
-import unittest
 from tinkertest import utils
 import tinkerer
 from tinkerer import page, post
@@ -20,7 +19,7 @@ class TestOrdering(utils.BaseTinkererTest):
     def test_ordering(self):
         utils.test = self
 
-        # create some pages and posts 
+        # create some pages and posts
         page.create("First Page")
         post.create("Oldest Post", datetime.date(2010, 10, 1))
         post.create("Newer Post", datetime.date(2010, 10, 1))
@@ -32,11 +31,15 @@ class TestOrdering(utils.BaseTinkererTest):
 
 
 ordering = {
-    tinkerer.master_doc : [None, None, "2010/10/01/newest_post"],
-    "2010/10/01/newest_post": [tinkerer.master_doc, tinkerer.master_doc, "2010/10/01/newer_post"],
-    "2010/10/01/newer_post": [tinkerer.master_doc, "2010/10/01/newest_post", "2010/10/01/oldest_post"],
-    "2010/10/01/oldest_post": [tinkerer.master_doc, "2010/10/01/newer_post", "pages/first_page"],
-    "pages/first_page": [tinkerer.master_doc, "2010/10/01/oldest_post", "pages/another_page"],
+    tinkerer.master_doc: [None, None, "2010/10/01/newest_post"],
+    "2010/10/01/newest_post": [tinkerer.master_doc, tinkerer.master_doc,
+                               "2010/10/01/newer_post"],
+    "2010/10/01/newer_post": [tinkerer.master_doc, "2010/10/01/newest_post",
+                              "2010/10/01/oldest_post"],
+    "2010/10/01/oldest_post": [tinkerer.master_doc, "2010/10/01/newer_post",
+                               "pages/first_page"],
+    "pages/first_page": [tinkerer.master_doc, "2010/10/01/oldest_post",
+                         "pages/another_page"],
     "pages/another_page": [tinkerer.master_doc, "pages/first_page", None]
 }
 
@@ -52,19 +55,19 @@ def build_finished(app, exception):
         utils.test.assertEquals(relations[docname], ordering[docname])
 
     # check metadata ordering is correct
-    utils.test.assertEquals([
-            "2010/10/01/newest_post",
-            "2010/10/01/newer_post",
-            "2010/10/01/oldest_post"],
-            env.blog_posts)
+    utils.test.assertEquals(
+        ["2010/10/01/newest_post",
+         "2010/10/01/newer_post",
+         "2010/10/01/oldest_post"],
+        env.blog_posts)
 
-    utils.test.assertEquals([
-            "pages/first_page",
-            "pages/another_page"],
-            env.blog_pages)
+    utils.test.assertEquals(
+        ["pages/first_page",
+         "pages/another_page"],
+        env.blog_pages)
 
 
-# extension setup    
+# extension setup
 def setup(app):
     if utils.is_module(app):
         return

--- a/tinkertest/test_page.py
+++ b/tinkertest/test_page.py
@@ -8,7 +8,6 @@
     CONTRIBUTORS file)
     :license: FreeBSD, see LICENSE file
 '''
-import datetime
 import os
 
 from tinkerer import page
@@ -28,21 +27,20 @@ class TestPage(utils.BaseTinkererTest):
         new_page = page.create("My Page")
 
         self.assertEquals(
-                os.path.abspath(os.path.join(
-                                    utils.TEST_ROOT, 
-                                    "pages", 
-                                    "my_page.rst")),
-                new_page.path)
+            os.path.abspath(os.path.join(
+                utils.TEST_ROOT,
+                "pages",
+                "my_page.rst")),
+            new_page.path)
 
         self.assertTrue(os.path.exists(new_page.path))
         self.assertEquals("pages/my_page", new_page.docname)
-
 
     # test moving existing file
     def test_move(self):
         # create a "pre-existing" file
         draft_file = os.path.join(utils.TEST_ROOT, "drafts", "afile.rst")
-        
+
         with open(draft_file, "w") as f:
             f.write("Content")
 
@@ -50,16 +48,15 @@ class TestPage(utils.BaseTinkererTest):
         moved_page = page.move(draft_file)
 
         self.assertEquals(
-                os.path.abspath(os.path.join(
-                                    utils.TEST_ROOT,
-                                    "pages",
-                                    "afile.rst")),
-                 moved_page.path)
+            os.path.abspath(os.path.join(
+                utils.TEST_ROOT,
+                "pages",
+                "afile.rst")),
+            moved_page.path)
 
         self.assertTrue(os.path.exists(moved_page.path))
         self.assertFalse(os.path.exists(draft_file))
         self.assertEquals("pages/afile", moved_page.docname)
-
 
     # test updating master document
     def test_master_update(self):
@@ -72,17 +69,17 @@ class TestPage(utils.BaseTinkererTest):
             self.assertEquals("   pages/page_1\n", lines[-3])
             self.assertEquals("   pages/page_2\n", lines[-2])
 
-
     # test content
     def test_content(self):
         new_page = page.create("My Page")
 
         # check expected empty page content
         with open(new_page.path) as f:
-            self.assertEquals(f.readlines(),
-                    ["My Page\n",
-                     "=======\n",
-                     "\n"])
+            self.assertEquals(
+                f.readlines(),
+                ["My Page\n",
+                 "=======\n",
+                 "\n"])
 
     # test that create duplicate page raises exception
     @raises(Exception)
@@ -92,7 +89,6 @@ class TestPage(utils.BaseTinkererTest):
 
         # should raise
         page.create("Page1")
-
 
     # test that moving page to existing page raises exception
     @raises(Exception)

--- a/tinkertest/test_patch.py
+++ b/tinkertest/test_patch.py
@@ -19,7 +19,7 @@ import sys
 class TestPatch(utils.BaseTinkererTest):
 
     def check_posts(self, filenames, posts, expected):
-        # helper function which creates given list of files and posts, runs a 
+        # helper function which creates given list of files and posts, runs a
         # build, then ensures expected content exists in each file
         for filename in filenames:
             with open(os.path.join(paths.root, filename), "w") as f:
@@ -29,12 +29,13 @@ class TestPatch(utils.BaseTinkererTest):
         # all posts are created on 2010/10/1 as date is not relevant here
         for new_post in posts:
             post.create(new_post[0], datetime.date(2010, 10, 1)).write(
-                    content = new_post[1])
+                content=new_post[1]
+            )
 
         # build and check output
         self.build()
 
-        # tests are tuples consisting of file path (as a list) and the list of 
+        # tests are tuples consisting of file path (as a list) and the list of
         # expected content
         for test in expected:
             with open(os.path.join(paths.html, *test[0]), "r") as f:
@@ -45,8 +46,6 @@ class TestPatch(utils.BaseTinkererTest):
                         print(content)
                     self.assertTrue(data in content)
 
-
-
     def test_patch_a_and_img(self):
         filenames = ["img.png"]
         posts = [
@@ -55,66 +54,58 @@ class TestPatch(utils.BaseTinkererTest):
         ]
 
         expected = [
-            (["2010", "10", "01", "post1.html"], 
-             [
-                # Sphinx running on Python3 has an achor here, Python2 doesn't
-                'href="post2.html#x"' if sys.version_info[0] == 3 else 
-                        'href="post2.html"',
-                'href="www.archlinux.org"'
-             ]),
+            # Sphinx running on Python3 has an achor here, Python2 doesn't
+            (["2010", "10", "01", "post1.html"],
+             [('href="post2.html#x"' if sys.version_info[0] == 3 else
+               'href="post2.html"'),
+              'href="www.archlinux.org"']),
+
+            # images get places in _images directory under root
             (["2010", "10", "01", "post2.html"],
-             [
-                # images get places in _images directory under root
-                'src="../../../_images/img.png"'
-             ]),
+             ['src="../../../_images/img.png"']),
+
+            # index.html should have links patched with relative address
             (["index.html"],
-             [
-                # index.html should have links patched with relative address
-                'href="2010/10/01/post2.html#x"',
-                'href="www.archlinux.org"',
-                'src="_images/img.png"'
-             ]),
+             ['href="2010/10/01/post2.html#x"',
+              'href="www.archlinux.org"',
+              'src="_images/img.png"']),
+
+            # RSS feed should have links patched with absolute address
             (["rss.html"],
-             [
-                # RSS feed should have links patched with absolute address
-                'href="http://127.0.0.1/blog/html/2010/10/01/post2.html#x"',
-                'href="www.archlinux.org"',
-                'src="http://127.0.0.1/blog/html/_images/img.png"'
-             ])
+             ['href="http://127.0.0.1/blog/html/2010/10/01/post2.html#x"',
+              'href="www.archlinux.org"',
+              'src="http://127.0.0.1/blog/html/_images/img.png"'])
         ]
 
         self.check_posts(filenames, posts, expected)
-
-
 
     def test_patch_target(self):
         # tests patching links for images with :target: specified
         filenames = ["img1.png", "img2.png", "img3.png"]
 
         posts = [
-            ("Post1", 
-                    # relative target
-                    ".. image:: ../../../img1.png\n"
-                    "   :target: ../../../_images/img1.png\n"
-                    "\n"
-                    # absolute target
-                    ".. image:: ../../../img2.png\n"
-                    "   :target: /_images/img2.png\n"
-                    "\n"
-                    # external target
-                    ".. image:: ../../../img3.png\n"
-                    "   :target: www.archlinux.org\n"
-            )
+            ("Post1",
+             # relative target
+             ".. image:: ../../../img1.png\n"
+             "   :target: ../../../_images/img1.png\n"
+             "\n"
+             # absolute target
+             ".. image:: ../../../img2.png\n"
+             "   :target: /_images/img2.png\n"
+             "\n"
+             # external target
+             ".. image:: ../../../img3.png\n"
+             "   :target: www.archlinux.org\n")
         ]
 
         expected = [
             (["2010", "10", "01", "post1.html"],
              [
-                # nothing should be changed
-                'href="../../../_images/img1.png"',
-                'href="/_images/img2.png"',
-                'href="www.archlinux.org"'
-             ]),
+                 # nothing should be changed
+                 'href="../../../_images/img1.png"',
+                 'href="/_images/img2.png"',
+                 'href="www.archlinux.org"']),
+
             (["index.html"],
              [
                 # relative target should get patched
@@ -122,8 +113,7 @@ class TestPatch(utils.BaseTinkererTest):
 
                 # absolute and external targets should be unchanged
                 'href="/_images/img2.png"',
-                'href="www.archlinux.org"'
-             ]),
+                'href="www.archlinux.org"']),
             (["rss.html"],
              [
                 # relative and absolute targets should get patched
@@ -131,21 +121,18 @@ class TestPatch(utils.BaseTinkererTest):
 
                 # absolute target doesn't get patched
                 # 'href="http://127.0.0.1/_images/img2.png"',
-                'href="www.archlinux.org"'
-             ])
+                'href="www.archlinux.org"'])
         ]
 
         self.check_posts(filenames, posts, expected)
-        
 
     def test_patch_bad_link(self):
         # post with an invalid link, which doesn't produce a proper <a> tag
         posts = [
-            ("Post1", 
-                    # bad link
-                "`http://book.cakephp.org/3.0/en/appendices/3-0-migration-\n"
-                "guide.html`_"
-            )
+            ("Post1",
+             # bad link
+             "`http://book.cakephp.org/3.0/en/appendices/3-0-migration-\n"
+             "guide.html`_")
         ]
 
         expected = [
@@ -154,9 +141,7 @@ class TestPatch(utils.BaseTinkererTest):
                 # should be marked as problematic by Sphinx
                 '<a href="#id1"><span class="problematic" id="id2">'
                 '`http://book.cakephp.org/3.0/en/appendices/3-0-migration-\n'
-                'guide.html`_</span></a>'
-             ])
+                'guide.html`_</span></a>'])
         ]
 
         self.check_posts([], posts, expected)
-

--- a/tinkertest/test_post.py
+++ b/tinkertest/test_post.py
@@ -34,13 +34,13 @@ class TestPost(utils.BaseTinkererTest):
         self.assertEquals(day, new_post.day)
 
         self.assertEquals(
-                os.path.abspath(os.path.join(
-                                    utils.TEST_ROOT, 
-                                    year, 
-                                    month, 
-                                    day, 
-                                    "my_post.rst")),
-                new_post.path)                                        
+            os.path.abspath(os.path.join(
+                utils.TEST_ROOT,
+                year,
+                month,
+                day,
+                "my_post.rst")),
+            new_post.path)
 
         self.assertTrue(os.path.exists(new_post.path))
 
@@ -51,13 +51,13 @@ class TestPost(utils.BaseTinkererTest):
         self.assertEquals("01", new_post.day)
 
         self.assertEquals(
-                os.path.abspath(os.path.join(
-                                    utils.TEST_ROOT,
-                                    "2010",
-                                    "10",
-                                    "01",
-                                    "date_post.rst")),
-                new_post.path)
+            os.path.abspath(os.path.join(
+                utils.TEST_ROOT,
+                "2010",
+                "10",
+                "01",
+                "date_post.rst")),
+            new_post.path)
 
         self.assertTrue(os.path.exists(new_post.path))
         self.assertEquals("2010/10/01/date_post", new_post.docname)
@@ -69,7 +69,7 @@ class TestPost(utils.BaseTinkererTest):
         os.chdir(utils.TEST_ROOT)
 
         with open("conf.py", "w") as f:
-            lines = f.write("slug_word_separator = '-'")
+            f.write("slug_word_separator = '-'")
 
         # create post with current date and dash as word separator
         new_post = post.create("My __Second  Post.")
@@ -82,13 +82,13 @@ class TestPost(utils.BaseTinkererTest):
         self.assertEquals(day, new_post.day)
 
         self.assertEquals(
-                os.path.abspath(os.path.join(
-                                    utils.TEST_ROOT, 
-                                    year, 
-                                    month, 
-                                    day, 
-                                    "my-second-post.rst")),
-                new_post.path)                                        
+            os.path.abspath(os.path.join(
+                utils.TEST_ROOT,
+                year,
+                month,
+                day,
+                "my-second-post.rst")),
+            new_post.path)
 
         self.assertTrue(os.path.exists(new_post.path))
 
@@ -96,7 +96,7 @@ class TestPost(utils.BaseTinkererTest):
     def test_move(self):
         # create a "pre-existing" file
         draft_file = os.path.join(utils.TEST_ROOT, "drafts", "afile.rst")
-        
+
         with open(draft_file, "w") as f:
             f.write("Content")
 
@@ -107,18 +107,17 @@ class TestPost(utils.BaseTinkererTest):
         self.assertEquals("01", moved_post.day)
 
         self.assertEquals(
-                os.path.abspath(os.path.join(
-                                    utils.TEST_ROOT,
-                                    "2010",
-                                    "10",
-                                    "01",
-                                    "afile.rst")),
-                 moved_post.path)
+            os.path.abspath(os.path.join(
+                utils.TEST_ROOT,
+                "2010",
+                "10",
+                "01",
+                "afile.rst")),
+            moved_post.path)
 
         self.assertTrue(os.path.exists(moved_post.path))
         self.assertFalse(os.path.exists(draft_file))
         self.assertEquals("2010/10/01/afile", moved_post.docname)
-
 
     # test updating master document
     def test_master_update(self):
@@ -137,7 +136,6 @@ class TestPost(utils.BaseTinkererTest):
             self.assertEquals("   2010/10/01/post_1\n", lines[lineno+3])
             self.assertEquals("\n", lines[lineno+4])
 
-
     # test content
     def test_content(self):
         # create post with no content
@@ -147,33 +145,34 @@ class TestPost(utils.BaseTinkererTest):
 
         # check expected empty post content
         with open(new_post.path) as f:
-            self.assertEquals(f.readlines(),
-                    ["My Post\n",
-                     "=======\n",
-                     "\n",
-                     "\n",
-                     "\n",
-                     ".. author:: default\n",
-                     ".. categories:: none\n",
-                     ".. tags:: none\n",
-                     ".. comments::\n"])
+            self.assertEquals(
+                f.readlines(),
+                ["My Post\n",
+                 "=======\n",
+                 "\n",
+                 "\n",
+                 "\n",
+                 ".. author:: default\n",
+                 ".. categories:: none\n",
+                 ".. tags:: none\n",
+                 ".. comments::\n"])
 
         # update post
-        new_post.write(author="Mr. Py", categories="category 1, category 2", 
-                tags="tag 1, tag 2", content="Lorem ipsum")
+        new_post.write(author="Mr. Py", categories="category 1, category 2",
+                       tags="tag 1, tag 2", content="Lorem ipsum")
 
         with open(new_post.path) as f:
-            self.assertEquals(f.readlines(),
-                    ["My Post\n",
-                     "=======\n",
-                     "\n",
-                     "Lorem ipsum\n",
-                     "\n",
-                     ".. author:: Mr. Py\n",
-                     ".. categories:: category 1, category 2\n",
-                     ".. tags:: tag 1, tag 2\n",
-                     ".. comments::\n"])
-
+            self.assertEquals(
+                f.readlines(),
+                ["My Post\n",
+                 "=======\n",
+                 "\n",
+                 "Lorem ipsum\n",
+                 "\n",
+                 ".. author:: Mr. Py\n",
+                 ".. categories:: category 1, category 2\n",
+                 ".. tags:: tag 1, tag 2\n",
+                 ".. comments::\n"])
 
     # test that create duplicate post raises exception
     @raises(Exception)
@@ -184,7 +183,6 @@ class TestPost(utils.BaseTinkererTest):
         # should raise
         post.create("Post1")
 
-
     # test that moving post to existing post raises exception
     @raises(Exception)
     def test_move_duplicate(self):
@@ -193,7 +191,6 @@ class TestPost(utils.BaseTinkererTest):
 
         # should raise
         post.move("Post1")
-
 
     # test creating post with no template
     @mock.patch("tinkerer.writer.render")
@@ -214,4 +211,3 @@ class TestPost(utils.BaseTinkererTest):
             mock.ANY,
             mock.ANY,
         )
-

--- a/tinkertest/test_readmore.py
+++ b/tinkertest/test_readmore.py
@@ -1,5 +1,5 @@
 '''
-    ReadMore Directive Test 
+    ReadMore Directive Test
     ~~~~~~~~~~~~~~~~~~~~~~~
 
     Tests readmore directive.
@@ -10,7 +10,7 @@
 '''
 import datetime
 import os
-from tinkerer import cmdline, draft, master, page, post
+from tinkerer import post
 from tinkertest import utils
 
 
@@ -22,7 +22,8 @@ class TestReadMore(utils.BaseTinkererTest):
 
         self.build()
 
-        post_path = os.path.join(utils.TEST_ROOT, 
+        post_path = os.path.join(
+            utils.TEST_ROOT,
             "blog", "html", "2010", "10", "01", "post1.html")
         post_html = open(post_path, "r").read()
 
@@ -30,11 +31,13 @@ class TestReadMore(utils.BaseTinkererTest):
         self.assertTrue('<div id="more"> </div>' in post_html)
 
         # ensure readmore is patched in aggregated page
-        index_path = os.path.join(utils.TEST_ROOT, 
+        index_path = os.path.join(
+            utils.TEST_ROOT,
             "blog", "html", "index.html")
         index_html = open(index_path, "r").read()
 
-        self.assertTrue(
+        expected = (
             '<p class="readmorewrapper"><a class="readmore"'
-            ' href="2010/10/01/post1.html#more">Read more...</a></p>' in index_html)
- 
+            ' href="2010/10/01/post1.html#more">Read more...</a></p>'
+        )
+        self.assertTrue(expected in index_html)

--- a/tinkertest/test_rss.py
+++ b/tinkertest/test_rss.py
@@ -25,8 +25,8 @@ import mock
 # get expected pubdate based on date
 def expected_pubdate(year, month, day):
     return email.utils.formatdate(
-                time.mktime(datetime.date(year, month, day).timetuple()),
-                localtime=True)
+        time.mktime(datetime.date(year, month, day).timetuple()),
+        localtime=True)
 
 
 # test case
@@ -47,8 +47,8 @@ class TestRSS(utils.BaseTinkererTest):
                     "amet, consectetuer",
                     "category 3")]:
             post.create(new_post[0], new_post[1]).write(
-                    content=new_post[2],
-                    categories=new_post[3])
+                content=new_post[2],
+                categories=new_post[3])
 
         self.build()
 
@@ -58,17 +58,19 @@ class TestRSS(utils.BaseTinkererTest):
         self.assertTrue(os.path.exists(feed_path))
 
         # check feed content
-        doc = xml.dom.minidom.parse(feed_path)
-        doc = doc.getElementsByTagName("rss")[0].getElementsByTagName("channel")[0]
+        parsed = xml.dom.minidom.parse(feed_path)
+        rss = parsed.getElementsByTagName("rss")[0]
+        channel = rss.getElementsByTagName("channel")
+        doc = channel[0]
 
         # validate XML channel data against expected content
         data = {
-                "title": None,
-                "link": None,
-                "description": None,
-                "language": None,
-                "pubDate": None
-               }
+            "title": None,
+            "link": None,
+            "description": None,
+            "language": None,
+            "pubDate": None
+        }
 
         data = self.get_data(doc, data)
 
@@ -80,37 +82,38 @@ class TestRSS(utils.BaseTinkererTest):
 
         # validate XML "item" node content against expected content
         data = {
-                "link": None,
-                "guid": None,
-                "title": None,
-                "description": None,
-                "category": None,
-                "pubDate": None
-               }
+            "link": None,
+            "guid": None,
+            "title": None,
+            "description": None,
+            "category": None,
+            "pubDate": None
+        }
 
-        for item in [{"index": 0,
-                      "link" : "http://127.0.0.1/blog/html/2010/12/03/post_3.html",
-                      "title": "Post 3",
-                      "description": "amet, consectetuer",
-                      "category": "category 3",
-                      "pubDate": expected_pubdate(2010, 12, 3)},
+        for item in [
+                {"index": 0,
+                 "link": "http://127.0.0.1/blog/html/2010/12/03/post_3.html",
+                 "title": "Post 3",
+                 "description": "amet, consectetuer",
+                 "category": "category 3",
+                 "pubDate": expected_pubdate(2010, 12, 3)},
 
-                     {"index": 1,
-                      "link" : "http://127.0.0.1/blog/html/2010/11/02/post_2.html",
-                      "title": "Post 2",
-                      "description": "dolor sit",
-                      "category": "category 2",
-                      "pubDate": expected_pubdate(2010, 11, 2)},
+                {"index": 1,
+                 "link": "http://127.0.0.1/blog/html/2010/11/02/post_2.html",
+                 "title": "Post 2",
+                 "description": "dolor sit",
+                 "category": "category 2",
+                 "pubDate": expected_pubdate(2010, 11, 2)},
 
-                     {"index": 2,
-                      "link" : "http://127.0.0.1/blog/html/2010/10/01/post_1.html",
-                      "title": "Post 1",
-                      "description": "Lorem ipsum",
-                      "category": "category 1",
-                      "pubDate": expected_pubdate(2010, 10, 1)}]:
+                {"index": 2,
+                 "link": "http://127.0.0.1/blog/html/2010/10/01/post_1.html",
+                 "title": "Post 1",
+                 "description": "Lorem ipsum",
+                 "category": "category 1",
+                 "pubDate": expected_pubdate(2010, 10, 1)}]:
 
             data = self.get_data(
-                    doc.getElementsByTagName("item")[item["index"]], data)
+                doc.getElementsByTagName("item")[item["index"]], data)
             self.assertEquals(item["link"], data["link"])
             self.assertEquals(item["link"], data["guid"])
             self.assertEquals(item["title"], data["title"])
@@ -118,13 +121,11 @@ class TestRSS(utils.BaseTinkererTest):
             self.assertTrue(item["category"] in data["category"])
             self.assertEquals(item["pubDate"], data["pubDate"])
 
-
-
     # get a dictionary of the given data in an XML node
     def get_data(self, node, data):
         for child in data.keys():
             data[child] = node.getElementsByTagName(
-                    child)[0].childNodes[0].nodeValue
+                child)[0].childNodes[0].nodeValue
 
         return data
 

--- a/tinkertest/test_tags.py
+++ b/tinkertest/test_tags.py
@@ -11,7 +11,6 @@
 import datetime
 import os
 from tinkerer import paths, post
-import unittest
 from tinkertest import utils
 
 
@@ -24,7 +23,8 @@ class TestTags(utils.BaseTinkererTest):
         for new_post in [("Post1", "tag #1"),
                          ("Post2", "tag #2"),
                          ("Post12", "tag #1, tag #2")]:
-            post.create(new_post[0], datetime.date(2010, 10, 1)).write(tags=new_post[1])
+            p = post.create(new_post[0], datetime.date(2010, 10, 1))
+            p.write(tags=new_post[1])
 
         utils.hook_extension("test_tags")
         self.build()
@@ -45,13 +45,16 @@ def build_finished(app, exception):
     # check post metadata
     for result in [([("tag__1", "tag #1")], "2010/10/01/post1"),
                    ([("tag__2", "tag #2")], "2010/10/01/post2"),
-                   ([("tag__1", "tag #1"), ("tag__2", "tag #2")], "2010/10/01/post12")]:
-        utils.test.assertEquals(result[0], 
-                app.builder.env.blog_metadata[result[1]].filing["tags"])
+                   ([("tag__1", "tag #1"), ("tag__2", "tag #2")],
+                    "2010/10/01/post12")]:
+        utils.test.assertEquals(
+            result[0],
+            app.builder.env.blog_metadata[result[1]].filing["tags"])
 
     # check tag pages were generated
     for page in ["tag__1.html", "tag__2.html"]:
-        utils.test.assertTrue(os.path.exists(os.path.join(paths.html, "tags", page)))
+        utils.test.assertTrue(os.path.exists(os.path.join(paths.html, "tags",
+                                                          page)))
 
 
 # extension setup
@@ -59,4 +62,3 @@ def setup(app):
     if utils.is_module(app):
         return
     app.connect("build-finished", build_finished)
- 

--- a/tinkertest/utils.py
+++ b/tinkertest/utils.py
@@ -8,11 +8,10 @@
     CONTRIBUTORS file)
     :license: FreeBSD, see LICENSE file
 '''
-import datetime
 import os
 import shutil
 import sys
-from tinkerer import cmdline, output, page, paths, post, writer
+from tinkerer import cmdline, output, paths, writer
 import types
 import unittest
 
@@ -32,12 +31,10 @@ class BaseTinkererTest(unittest.TestCase):
         output.quiet = True
         setup()
 
-
     # invoke build
     def build(self):
         print("")
         self.assertEquals(0, cmdline.build())
-
 
     # common teardown - cleanup working directory
     def tearDown(self):
@@ -70,7 +67,7 @@ def cleanup():
 # nose mistakenly calls Sphinx extension setup functions thinking they are
 # test setups with a module parameter
 def is_module(m):
-    return type(m) is types.ModuleType
+    return isinstance(m, types.ModuleType)
 
 
 # used by Sphinx to lookup extensions

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ commands = nosetests {posargs}
 skipdist = True
 usedevelop = True
 deps = flake8
-commands = flake8 tinkerer tinkertests
+commands = flake8 tinkerer tinkertest
 
 [testenv:cover]
 deps =


### PR DESCRIPTION
Clean up whitespace, extra imports, redefined symbols, and other errors and
warnings reported by flake8.

Add flake8 to the commands run by travis.

Change-Id: Id3bdea24cad61c13c163970a4a13bc47e4ece553
