### PR TITLE
Filter templates when calculating tags and categories

### DIFF
--- a/tinkerer/ext/metadata.py
+++ b/tinkerer/ext/metadata.py
@@ -178,9 +178,9 @@ def add_metadata(app, pagename, context):
     context["recent"] = [(post, env.titles[post].astext()) for post
                          in env.blog_posts[:20]]
     # tags & categories
-    tags = dict((t, 0) for t in env.filing["tags"] if not t.startswith('{{'))
+    tags, categories = [dict([(p, 0) for p in env.filing[c] if not
+                        p.startswith('{{')]) for c in ["tags", "categories"]]
     taglinks = dict((t, name_from_title(t)) for t in tags)
-    categories = dict((c, 0) for c in env.filing["categories"] if not c.startswith('{{'))
     catlinks = dict([(c, name_from_title(c)) for c in categories])
 
     for post in env.blog_posts:


### PR DESCRIPTION
Prior to this change sphinx would consume the templates which include
templatized placeholders like "{{ tags }}", and these would show up in
the sidebar as literal tags and categories with zero counts.
