### PR TITLE
support for buildout environments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ RSS feed generation, comments powered by Disqus and more.
 Tinkerer is also highly customizable through Sphinx extensions.
 '''
 
-requires = ["Jinja2>=2.3", "Sphinx>=1.2.3", "Babel>=1.3", "pyquery>=1.2.8"]
+requires = ["Jinja2>=2.3", "Sphinx>=1.2.3", "Babel>=1.3", "pyquery>=1.2.8", "mock>=1.0.1"]
 if sys.version_info[:2] < (2,7) or (sys.version_info.major == 3 and
                                     sys.version_info.minor < 2):
     requires.append("argparse>=1.2")

--- a/tinkerer/cmdline.py
+++ b/tinkerer/cmdline.py
@@ -17,7 +17,7 @@ import argparse
 from datetime import datetime
 import os
 import shutil
-import subprocess
+from sphinx import build_main
 import tinkerer
 from tinkerer import draft, output, page, paths, post, writer
 
@@ -59,7 +59,7 @@ def build():
     if os.path.exists("_copy"):
         shutil.copytree("_copy/", paths.html)
 
-    return subprocess.call(flags)
+    return build_main(flags)
 
 
 def create_post(title, date, template):


### PR DESCRIPTION
fixed build command so `tinkerer --build` can also be used when using tinkerer in buildout environment, e.g.:

``` cfg
[buildout]
parts = eggs

[eggs]
recipe = zc.recipe.egg
dependent-scripts = true
eggs = tinkerer
```

this requires that sphinx's build_main command is called directly instead of spawing new subprocess (which would require to have sphinx installed globally).
