### PR TITLE
Remove patched code to visit and depart literals

### DIFF
--- a/tinkerer/ext/html5.py
+++ b/tinkerer/ext/html5.py
@@ -38,24 +38,6 @@ def depart_desc_name(self, node):
     '''
     self.body.append('</span>')
 
-
-def visit_literal(self, node):
-    '''
-    Similar to Sphinx but using a <span> node instead of <tt>.
-    '''
-    self.body.append(self.starttag(node, 'span', '',
-                                   CLASS='docutils literal'))
-    self.protect_literal_text += 1
-
-
-def depart_literal(self, node):
-    '''
-    Similar to Sphinx but using a <span> node instead of <tt>.
-    '''
-    self.protect_literal_text -= 1
-    self.body.append('</span>')
-
-
 def patch_translator():
     '''
     Monkey-patch Sphinx translator to emit proper HTML5.
@@ -64,5 +46,3 @@ def patch_translator():
     HTMLTranslator.depart_desc_addname = depart_desc_addname
     HTMLTranslator.visit_desc_name = visit_desc_name
     HTMLTranslator.depart_desc_name = depart_desc_name
-    HTMLTranslator.visit_literal = visit_literal
-    HTMLTranslator.depart_literal = depart_literal

--- a/tinkerer/ext/html5.py
+++ b/tinkerer/ext/html5.py
@@ -38,6 +38,7 @@ def depart_desc_name(self, node):
     '''
     self.body.append('</span>')
 
+
 def patch_translator():
     '''
     Monkey-patch Sphinx translator to emit proper HTML5.


### PR DESCRIPTION
Sphinx by now uses a HTML5 compliant element `<code>` to represent inline literals. Remove patching code to keep in line with the current stable release of Sphinx (https://github.com/sphinx-doc/sphinx/blob/1.3.1/sphinx/writers/html.py#L373-L380)
