### PR TITLE
Make blog path configurable [#98]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist/*
 .tox/*
 .ropeproject
 .coverage
+.idea/*

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -31,3 +31,4 @@ David Boucha - Spelling fixes
 Troels Brødsgaard - Update localization pot file, localize "Search" string
 John McFarlane - Bug fixes
 Karsten Schulz - Updated German localization
+Anil Lakhman - Configurable Blog Path via environment variable "TINKERER_BLOG_PATH" [#98]

--- a/blog/doc/command_line.rst
+++ b/blog/doc/command_line.rst
@@ -92,3 +92,26 @@ Verbosity can be change with one of the mutually exclusive flags:
         tinker --post `Hello World!` -f | xargs vim
 
 Back to :ref:`tinkerer_reference`.
+
+Custom Blog Path
+----------------
+
+.. highlight:: bash
+
+By default, ``tinker`` will write the newly generated post to the ``blog`` directory.::
+
+    # [Default] Writes to the `blog` directory
+    tinker --post 'Hello World!'
+
+    # Outputs to: `blog/2016/06/12/hello_world.rst`
+
+You can change this by adding the ``TINKERER_BLOG_PATH`` environment variable with the name of another directory to use.::
+
+    # Update your .bash_profile
+    # Generate files in the "posts" directory instead of "blog"
+    export TINKERER_BLOG_PATH="posts"
+
+    # [Custom] Writes to the `posts` directory
+    tinker --post 'Hello World!'
+
+    # Outputs to: `posts/2016/06/12/hello_world.rst`

--- a/tinkerer/paths.py
+++ b/tinkerer/paths.py
@@ -44,7 +44,7 @@ def set_paths(root_path="."):
     '''
     global root, blog, doctree, html, master_file, index_file, conf_file
     root = os.path.abspath(root_path)
-    blog = os.path.join(root, "blog")
+    blog = os.path.join(root, os.getenv("TINKERER_BLOG_PATH", "blog"))
     doctree = os.path.join(blog, "doctrees")
     html = os.path.join(blog, "html")
     master_file = os.path.join(root,


### PR DESCRIPTION
- Blog path used in cmdline can be configured with environment variable 'TINKERER_BLOG_PATH'
- Added IntelliJ .idea to .gitignore
- Added Documentation example

Closes **#98**.

Simple 1 liner change, if the environment variable `TINKERER_BLOG_PATH` is set, use it, else default to `blog`.

Useful for me as I can't use the command line without overwriting older posts already in the `blog` directory (from another blog).

No breaking changes, causes no issues for all existing users.