### PR TITLE
Specify an upper bound on the Sphinx requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,12 @@ RSS feed generation, comments powered by Disqus and more.
 Tinkerer is also highly customizable through Sphinx extensions.
 '''
 
-requires = ["Jinja2>=2.3", "Sphinx>=1.6.1", "Babel>=1.3", "pyquery>=1.2.8"]
+requires = [
+    "Jinja2>=2.3",
+    "Sphinx>=1.6.1,<1.7.0",
+    "Babel>=1.3",
+    "pyquery>=1.2.8",
+]
 
 test_requires = ['nose', 'tox']
 


### PR DESCRIPTION
Sphinx 1.7 removes `Directive` from `sphinx.compat` (which the
`tinkerer.blog` extension requires).

Fixes #108.