### PR TITLE
Updates sphinx dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ RSS feed generation, comments powered by Disqus and more.
 Tinkerer is also highly customizable through Sphinx extensions.
 '''
 
-requires = ["Jinja2>=2.3", "Sphinx==1.7.1", "Babel>=1.3", "pyquery>=1.2.8"]
+requires = ["Jinja2>=2.3", "Sphinx==1.8.0", "Babel>=1.3", "pyquery>=1.2.8"]
 
 test_requires = ['nose', 'tox']
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ RSS feed generation, comments powered by Disqus and more.
 Tinkerer is also highly customizable through Sphinx extensions.
 '''
 
-requires = ["Jinja2>=2.3", "Sphinx==1.8.5", "Babel>=1.3", "pyquery>=1.2.8"]
+requires = ["Jinja2>=2.3", "Sphinx==2.0.0", "Babel>=1.3", "pyquery>=1.2.8"]
 
 test_requires = ['nose', 'tox']
 

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         ]
     },
     install_requires = requires,
-    test_requires = test_requires,
+    tests_require = test_requires,
     test_suite = 'nose.collector',
     message_extractors = {
         'tinkerer': [

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ RSS feed generation, comments powered by Disqus and more.
 Tinkerer is also highly customizable through Sphinx extensions.
 '''
 
-requires = ["Jinja2>=2.3", "Sphinx==1.8.0", "Babel>=1.3", "pyquery>=1.2.8"]
+requires = ["Jinja2>=2.3", "Sphinx==1.8.5", "Babel>=1.3", "pyquery>=1.2.8"]
 
 test_requires = ['nose', 'tox']
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ RSS feed generation, comments powered by Disqus and more.
 Tinkerer is also highly customizable through Sphinx extensions.
 '''
 
-requires = ["Jinja2>=2.3", "Sphinx==2.0.0", "Babel>=1.3", "pyquery>=1.2.8"]
+requires = ["Jinja2>=2.3", "Sphinx>=2.3.0", "Babel>=1.3", "pyquery>=1.2.8"]
 
 test_requires = ['nose', 'tox']
 

--- a/tinkerer/ext/blog.py
+++ b/tinkerer/ext/blog.py
@@ -123,7 +123,6 @@ def setup(app):
     # new config values
     app.add_config_value("tagline", "My blog", True)
     app.add_config_value("description", "My blog", True)
-    app.add_config_value("author", "Winston Smith", True)
     app.add_config_value("rss_service", None, True)
     app.add_config_value("rss_generate_full_posts", False, True)
     app.add_config_value("website", "http://127.0.0.1/blog/html/", True)

--- a/tinkertest/utils.py
+++ b/tinkertest/utils.py
@@ -10,8 +10,8 @@
 '''
 import os
 import shutil
-import sphinx
 import sys
+from sphinx.cmd.build import main as build_main
 from tinkerer import output, paths, writer
 import types
 import unittest
@@ -35,9 +35,9 @@ class BaseTinkererTest(unittest.TestCase):
     # invoke build
     def build(self, expected_return=0):
         print("")
-        sys.argv = ["sphinx-build", "-q", "-d", paths.doctree, "-b",
+        sys.argv = ["-q", "-d", paths.doctree, "-b",
                     "html", paths.root, paths.html]
-        sphinx.main(sys.argv)
+        build_main(sys.argv)
 
     # common teardown - cleanup working directory
     def tearDown(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,25 @@
 [tox]
-envlist = py36
+envlist =
+  py37,
+  py38,
+  flake8
 
-[testenv]
-deps =
+[py]
+deps=
   nose
   mock
+
+[testenv]
 commands = nosetests {posargs}
+setenv = LANG = C
+
+[testenv:py37]
+deps={[py]deps}
+basepython=python3.7
+
+[testenv:py38]
+deps={[py]deps}
+basepython=python3.8
 
 [testenv:flake8]
 skipdist = True
@@ -14,8 +28,7 @@ deps = flake8
 commands = flake8 tinkerer tinkertest
 
 [testenv:cover]
-deps =
-  nose
+deps={[py]deps}
   coverage
-basepython=python3.6
+basepython=python3.8
 commands = nosetests --with-cover --cover-package=tinkerer --cover-inclusive {posargs}


### PR DESCRIPTION
Hi,

I fixes to support Sphinx 2.3.0, and Python 3.7, 3.8.
If you like, could you please merge the pull request?

The main modifications are as follows.

1. tox on python 3.7, python3.8.
- Appends `setenv = LANG = C` for Non-English LANG.
- Drops Python 3.6 supports. (Python 3.6 does not work on Debian GNU/Linux bullseye/Sid.)

2. Fixes config.author bug for Sphinx >= 1.8.0.
3. Fixes sphinx.main() of unittest for Sphinx >= 2.0.0.
4. Fixes setup argument `test_requries`.
5. Supports Sphinx version >= 2.3.0.

I develops and tests using Pipenv.
```bash
$ pipenv --python 3.7
$ pipenv install tox
$ pipenv run tox
```

But not fixes `RemovedInSphinx30Warning`.

```
/path/to/tinkerer/tinkerer/themes/boilerplate/search.html:20: 
RemovedInSphinx30Warning: To modify script_files in the theme is deprecated.
Please insert a <script> tag directly in your theme instead.
```

Best regards,