### PR TITLE
docs: Fix a few typos

### DIFF
--- a/blog/2012/07/05/tinkerer_0_4_beta_released.rst
+++ b/blog/2012/07/05/tinkerer_0_4_beta_released.rst
@@ -13,7 +13,7 @@ New HTML5 Themes
   *boilerplate* and including a lot more detail-work
 
 The old themes (*tinkerbase*, *modern* and *minimal*) are still around for
-backwards compatiblity, though future development will happen around
+backwards compatibility, though future development will happen around
 HTML5-based themes.
 
 New Built-in Extensions

--- a/blog/2013/06/05/tinkerer_1_2_released.rst
+++ b/blog/2013/06/05/tinkerer_1_2_released.rst
@@ -5,7 +5,7 @@ What's New
 ----------
 
 * Tinkerer moved to GitHub! Old repositories on BitBucket are still there for
-  the time being, but going forward, all developement will take place on GitHub.
+  the time being, but going forward, all development will take place on GitHub.
   Make sure to star/fork Tinkerer `here <https://github.com/vladris/tinkerer>`_
 * A brand new *flat* theme optimized around distraction-free reading and a
   customized Pygments style displaying code in the

--- a/blog/doc/extensions.rst
+++ b/blog/doc/extensions.rst
@@ -59,7 +59,7 @@ Sphinx. It contains the following extra keys:
 
 ``Metadata``
 
-    This is an object containig additional metadata:
+    This is an object containing additional metadata:
 
     ``is_post``, ``is_page``
 

--- a/blog/pages/extensions.rst
+++ b/blog/pages/extensions.rst
@@ -7,7 +7,7 @@ come with Tinkerer, you can get an assortment of additional extensions.
 Community extensions are Tinkerer extensions contributed and maintained by
 various authors. They are not part of the Tinkerer distribution, but they can
 be acquired separately from the
-`tinkerer-contrib respository <https://github.com/vladris/tinkerer-contrib>`_.
+`tinkerer-contrib repository <https://github.com/vladris/tinkerer-contrib>`_.
 
 Extensions usually go in your blog's ``_exts`` directory. Additional setup
 steps are provided for each extension.

--- a/tinkerer/ext/filing.py
+++ b/tinkerer/ext/filing.py
@@ -2,7 +2,7 @@
     filing
     ~~~~~~
 
-    Handles post filing by date, caregories and tags.
+    Handles post filing by date, categories and tags.
 
     :copyright: Copyright 2011-2018 by Vlad Riscutia and contributors (see
     CONTRIBUTORS file)

--- a/tinkerer/ext/metadata.py
+++ b/tinkerer/ext/metadata.py
@@ -207,7 +207,7 @@ def add_metadata(app, pagename, context):
                 context["prev"] = None
             if pagename == env.blog_posts[-1]:
                 context["next"] = None
-        # if this is not documententation
+        # if this is not documentation
         elif not (pagename.startswith("doc/") or pagename.startswith("docs/")):
             # no rellinks for non-posts/docs
             context["prev"], context["next"] = None, None

--- a/tinkertest/test_categories.py
+++ b/tinkertest/test_categories.py
@@ -2,7 +2,7 @@
     Categories Test
     ~~~~~~~~~~~~~~~
 
-    Tests Tinkerer post categoires.
+    Tests Tinkerer post categories.
 
     :copyright: Copyright 2011-2018 by Vlad Riscutia and contributors (see
     CONTRIBUTORS file)
@@ -21,7 +21,7 @@ class TestCategories(utils.BaseTinkererTest):
 
         # create some posts with categories
 
-        # missing category for Post1 ("cateogry #1,") should work,
+        # missing category for Post1 ("category #1,") should work,
         # just issue a warning
         for new_post in [("Post1", "category #1,"),
                          ("Post2", "category #2"),

--- a/tinkertest/test_cmdline.py
+++ b/tinkertest/test_cmdline.py
@@ -116,7 +116,7 @@ class TestCmdLine(utils.BaseTinkererTest):
 
         file_path = os.path.join(utils.TEST_ROOT, "pages", "my_test_page.rst")
 
-        # assert file exsits
+        # assert file exists
         self.assertTrue(os.path.exists(file_path))
 
     # test page from existing file

--- a/tinkertest/test_master.py
+++ b/tinkertest/test_master.py
@@ -37,7 +37,7 @@ class TestMaster(utils.BaseTinkererTest):
 
         master.append_doc(new_docs[0])
 
-        # first doc should be appendend in the correct place
+        # first doc should be appended in the correct place
         self.assertEquals(
             TestMaster.MASTER_HEAD +
             ["   %s\n" % new_docs[0]] +

--- a/tinkertest/test_patch.py
+++ b/tinkertest/test_patch.py
@@ -2,7 +2,7 @@
     Patch Test
     ~~~~~~~~~~
 
-    Tests link patching on aggreated pages and RSS feed.
+    Tests link patching on aggregate pages and RSS feed.
 
     :copyright: Copyright 2011-2018 by Vlad Riscutia and contributors (see
     CONTRIBUTORS file)


### PR DESCRIPTION
There are small typos in:
- blog/2012/07/05/tinkerer_0_4_beta_released.rst
- blog/2013/06/05/tinkerer_1_2_released.rst
- blog/doc/extensions.rst
- blog/pages/extensions.rst
- tinkerer/ext/filing.py
- tinkerer/ext/metadata.py
- tinkertest/test_categories.py
- tinkertest/test_cmdline.py
- tinkertest/test_master.py
- tinkertest/test_patch.py

Fixes:
- Should read `repository` rather than `respository`.
- Should read `exists` rather than `exsits`.
- Should read `documentation` rather than `documententation`.
- Should read `development` rather than `developement`.
- Should read `containing` rather than `containig`.
- Should read `compatibility` rather than `compatiblity`.
- Should read `category` rather than `cateogry`.
- Should read `categories` rather than `categoires`.
- Should read `categories` rather than `caregories`.
- Should read `appended` rather than `appendend`.
- Should read `aggregate` rather than `aggreated`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md